### PR TITLE
Updated pitch control saturation & output file update

### DIFF
--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -178,6 +178,7 @@ CONTAINS
 
                 ! TEST INTERP2D
                 lambda = LocalVar%RotSpeed * CntrPar%WE_BladeRadius/v_h
+                DebugVar%WE_Pitch = LocalVar%BlPitch(1)
                 Cp_op = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%BlPitch(1)*R2D, lambda )
                 Cp_op = max(0.0,Cp_op)
                 

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -68,7 +68,7 @@ CONTAINS
         IF (LocalVar%iStatus == 0) THEN
             LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, CntrPar%PC_FinePit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%PitCom(1), .TRUE., objInst%instPI)
         ELSE
-            LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, CntrPar%PC_FinePit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%BlPitch(1), .FALSE., objInst%instPI)
+            LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, LocalVar%PC_MinPit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%BlPitch(1), .FALSE., objInst%instPI)
         END IF
         
         ! Find individual pitch control contribution

--- a/src/DISCON.F90
+++ b/src/DISCON.F90
@@ -55,6 +55,7 @@ TYPE(ObjectInstances), SAVE           :: objInst
 TYPE(PerformanceData), SAVE           :: PerfData
 TYPE(DebugVariables), SAVE            :: DebugVar
 
+RootName = TRANSFER(avcOUTNAME, RootName)
 !------------------------------------------------------------------------------------------------------------------------------
 ! Main control calculations
 !------------------------------------------------------------------------------------------------------------------------------

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -275,8 +275,8 @@ CONTAINS
         fQ(1,2) = zData(i,jj)
         fQ(2,2) = zData(ii,jj)
         ! Interpolate
-        fxy1 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,1)
-        fxy2 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,2) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,1)
+        fxy1 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(1,2)
+        fxy2 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(2,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,2)
         fxy = (yData(ii) - yq)/(yData(ii) - yData(i))*fxy1 + (yq - yData(i))/(yData(ii) - yData(i))*fxy2
 
         interp2d = fxy(1)
@@ -472,7 +472,7 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 8
+        nDebugOuts = 9
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         DebugOutStr1  = 'IMU_FA_AccF';     DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
@@ -483,13 +483,16 @@ CONTAINS
         DebugOutStr6  = 'WE_Cp';           DebugOutUni6  = '(-)';        DebugOutData(6)  = DebugVar%WE_Cp
         DebugOutStr7  = 'PC_MinPit';       DebugOutUni7  = '(rad)';      DebugOutData(7)  = LocalVar%PC_MinPit
         DebugOutStr8  = 'SS_dOmF';         DebugOutUni8  = '(rad/s)';    DebugOutData(8)  = LocalVar%SS_DelOmegaF
+        DebugOutStr9  = 'WE_Pitch';        DebugOutUni8  = '(rad)';      DebugOutData(9)  = DebugVar%WE_Pitch
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
         DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
-                                                DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8]
+                                                DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
+                                                DebugOutStr9]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
-                                                DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8]
+                                                DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
+                                                DebugOutUni9]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL
@@ -521,7 +524,7 @@ CONTAINS
 
         ! Want debug on first timestep
         IF (CntrPar%LoggingLevel > 0) THEN
-            WRITE (UnDb,FmtDat)     LocalVar%Time, LocalVar%NacIMU_FA_AccF, LocalVar%WE_Vw, LocalVar%NacIMU_FA_Acc, LocalVar%FA_Acc, LocalVar%Fl_PitCom, DebugVar%WE_Cp, LocalVar%PC_MinPit, LocalVar%SS_DelOmegaF
+            WRITE (UnDb,FmtDat)  LocalVar%Time, DebugOutData
         END IF
         
         IF (MODULO(LocalVar%Time, 10.0) == 0.0) THEN

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -496,7 +496,7 @@ CONTAINS
         ! If we're debugging, open the debug file and write the header:
             ! Note that the headers will be Truncated to 10 characters!!
             IF (CntrPar%LoggingLevel > 0) THEN
-                OPEN(unit=UnDb, FILE='DEBUG.dbg')
+                OPEN(unit=UnDb, FILE=RootName(1:size_avcOUTNAME-5)//'RO.out')
                 WRITE (UnDb,'(99(a10,TR5:))') 'Time',   DebugOutStrings
                 WRITE (UnDb,'(99(a10,TR5:))') '(sec)',  DebugOutUnits
             END IF

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -215,6 +215,7 @@ END TYPE PerformanceData
 
 TYPE, PUBLIC :: DebugVariables
     REAL(4)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_Pitch                       ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types


### PR DESCRIPTION
Major Updates:
 - Controllers.f90: changed lower limit of pitch control to minimum pitch saturation limit, which prevents windup when pitch is saturated and reduces generator speed (and other transients)

Minor Updates:
- DISCON.f90, Functions.f90: will output Debug.dbg as <base_sim_name>.RO.out to enable wider use of the internal ROSCO signals as simulation outputs