### PR TITLE
Fix Pitch Saturation, Floating Control Pitch Offset

### DIFF
--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -178,6 +178,7 @@ CONTAINS
 
                 ! TEST INTERP2D
                 lambda = LocalVar%RotSpeed * CntrPar%WE_BladeRadius/v_h
+                DebugVar%WE_Pitch = LocalVar%BlPitch(1)
                 Cp_op = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%BlPitch(1)*R2D, lambda )
                 Cp_op = max(0.0,Cp_op)
                 

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -144,6 +144,11 @@ CONTAINS
         REAL(4), DIMENSION(3,1), SAVE   :: K        ! Kalman gain matrix
         REAL(4)                         :: R_m      ! Measurement noise covariance [(rad/s)^2]
         
+        ! ---- Debug Inputs ------
+        DebugVar%WE_b   = LocalVar%PC_PitComTF*R2D
+        DebugVar%WE_w   = LocalVar%RotSpeedF
+        DebugVar%WE_t   = LocalVar%VS_LastGenTrqF
+
         ! ---- Define wind speed estimate ---- 
         
         ! Inversion and Invariance Filter implementation

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -213,6 +213,7 @@ CONTAINS
                 K = MATMUL(P,TRANSPOSE(H))/S(1,1)
                 xh = xh + K*(LocalVar%RotSpeedF - om_r)
                 P = MATMUL(identity(3) - MATMUL(K,H),P)
+
                 
                 ! Wind Speed Estimate
                 om_r = xh(1,1)
@@ -223,6 +224,8 @@ CONTAINS
 
                 ! Debug Outputs
                 DebugVar%WE_Cp = Cp_op
+                DebugVar%WE_D = v_m
+
             ENDIF
 
         ELSE        

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -268,12 +268,10 @@ CONTAINS
         TYPE(LocalVariables), INTENT(INOUT)     :: LocalVar 
         TYPE(ObjectInstances), INTENT(INOUT)    :: objInst
         ! Allocate Variables 
-        REAL(4)                     :: V_towertop ! Estimated velocity of tower top (m/s)
         REAL(4)                     :: Vhat     ! Estimated wind speed without towertop motion [m/s]
         REAL(4)                     :: Vhatf     ! 30 second low pass filtered Estimated wind speed without towertop motion [m/s]
 
-        V_towertop = PIController(LocalVar%FA_Acc, 0.0, 1.0, -100.0, 100.0, LocalVar%DT, 0.0, .FALSE., objInst%instPI)
-        Vhat = LocalVar%WE_Vw_F + V_towertop
+        Vhat = LocalVar%WE_Vw_F
         Vhatf = SecLPFilter(Vhat,LocalVar%DT,0.21,0.7,LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         
         ! Define minimum blade pitch angle as a function of estimated wind speed

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -68,7 +68,7 @@ CONTAINS
         IF (LocalVar%iStatus == 0) THEN
             LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, CntrPar%PC_FinePit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%PitCom(1), .TRUE., objInst%instPI)
         ELSE
-            LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, CntrPar%PC_FinePit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%BlPitch(1), .FALSE., objInst%instPI)
+            LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, LocalVar%PC_MinPit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%BlPitch(1), .FALSE., objInst%instPI)
         END IF
         
         ! Find individual pitch control contribution

--- a/src/DISCON.F90
+++ b/src/DISCON.F90
@@ -55,6 +55,7 @@ TYPE(ObjectInstances), SAVE           :: objInst
 TYPE(PerformanceData), SAVE           :: PerfData
 TYPE(DebugVariables), SAVE            :: DebugVar
 
+RootName = TRANSFER(avcOUTNAME, RootName)
 !------------------------------------------------------------------------------------------------------------------------------
 ! Main control calculations
 !------------------------------------------------------------------------------------------------------------------------------

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -274,8 +274,13 @@ CONTAINS
 
         ! Filtering the tower fore-aft acceleration signal 
         IF (CntrPar%Fl_Mode == 1) THEN
-            LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
-            ! LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_FlCornerFreq/3, LocalVar%iStatus, .FALSE., objInst%instHPF) 
+            ! Force to start at 0
+            IF (LocalVar%iStatus == 0) THEN
+                LocalVar%NacIMU_FA_AccF = SecLPFilter(0., LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+            ELSE
+                LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+            ENDIF
+                LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, 0.0167, LocalVar%iStatus, .FALSE., objInst%instHPF) 
             ! LocalVar%NacIMU_FA_AccF = NotchFilterSlopes(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instNotchSlopes) ! Fixed Damping
             IF (CntrPar%F_NotchType >= 2) THEN
                 LocalVar%NACIMU_FA_AccF = NotchFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_NotchCornerFreq, CntrPar%F_NotchBetaNumDen(1), CntrPar%F_NotchBetaNumDen(2), LocalVar%iStatus, .FALSE., objInst%instNotch) ! Fixed Damping

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -275,8 +275,8 @@ CONTAINS
         fQ(1,2) = zData(i,jj)
         fQ(2,2) = zData(ii,jj)
         ! Interpolate
-        fxy1 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,1)
-        fxy2 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,2) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,1)
+        fxy1 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(1,2)
+        fxy2 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(2,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,2)
         fxy = (yData(ii) - yq)/(yData(ii) - yData(i))*fxy1 + (yq - yData(i))/(yData(ii) - yData(i))*fxy2
 
         interp2d = fxy(1)
@@ -472,7 +472,7 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 8
+        nDebugOuts = 9
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         DebugOutStr1  = 'IMU_FA_AccF';     DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
@@ -483,13 +483,16 @@ CONTAINS
         DebugOutStr6  = 'WE_Cp';           DebugOutUni6  = '(-)';        DebugOutData(6)  = DebugVar%WE_Cp
         DebugOutStr7  = 'PC_MinPit';       DebugOutUni7  = '(rad)';      DebugOutData(7)  = LocalVar%PC_MinPit
         DebugOutStr8  = 'SS_dOmF';         DebugOutUni8  = '(rad/s)';    DebugOutData(8)  = LocalVar%SS_DelOmegaF
+        DebugOutStr9  = 'WE_Pitch';        DebugOutUni8  = '(rad)';      DebugOutData(9)  = DebugVar%WE_Pitch
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
         DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
-                                                DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8]
+                                                DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
+                                                DebugOutStr9]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
-                                                DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8]
+                                                DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
+                                                DebugOutUni9]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL
@@ -521,7 +524,7 @@ CONTAINS
 
         ! Want debug on first timestep
         IF (CntrPar%LoggingLevel > 0) THEN
-            WRITE (UnDb,FmtDat)     LocalVar%Time, LocalVar%NacIMU_FA_AccF, LocalVar%WE_Vw, LocalVar%NacIMU_FA_Acc, LocalVar%FA_Acc, LocalVar%Fl_PitCom, DebugVar%WE_Cp, LocalVar%PC_MinPit, LocalVar%SS_DelOmegaF
+            WRITE (UnDb,FmtDat)  LocalVar%Time, DebugOutData
         END IF
         
         IF (MODULO(LocalVar%Time, 10.0) == 0.0) THEN

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -496,7 +496,7 @@ CONTAINS
         ! If we're debugging, open the debug file and write the header:
             ! Note that the headers will be Truncated to 10 characters!!
             IF (CntrPar%LoggingLevel > 0) THEN
-                OPEN(unit=UnDb, FILE='DEBUG.dbg')
+                OPEN(unit=UnDb, FILE=RootName(1:size_avcOUTNAME-5)//'RO.out')
                 WRITE (UnDb,'(99(a10,TR5:))') 'Time',   DebugOutStrings
                 WRITE (UnDb,'(99(a10,TR5:))') '(sec)',  DebugOutUnits
             END IF

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -471,27 +471,29 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 9
+        nDebugOuts = 11
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
-        DebugOutStr1  = 'IMU_FA_AccF';     DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
+        DebugOutStr1  = 'FA_AccF';         DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
         DebugOutStr2  = 'WE_Vw';           DebugOutUni2  = '(rad)';      DebugOutData(2)  = LocalVar%WE_Vw
-        DebugOutStr3  = 'IMU_FA_Acc';      DebugOutUni3  = '(rad/s^2)';  DebugOutData(3)  = LocalVar%NacIMU_FA_Acc
+        DebugOutStr3  = 'FA_AccR';          DebugOutUni3  = '(rad/s^2)';  DebugOutData(3)  = LocalVar%NacIMU_FA_Acc
         DebugOutStr4  = 'FA_Acc';          DebugOutUni4  = '(m/s^2)';    DebugOutData(4)  = LocalVar%FA_Acc
         DebugOutStr5  = 'Fl_Pitcom';       DebugOutUni5  = '(rad)';      DebugOutData(5)  = LocalVar%Fl_Pitcom
         DebugOutStr6  = 'WE_Cp';           DebugOutUni6  = '(-)';        DebugOutData(6)  = DebugVar%WE_Cp
         DebugOutStr7  = 'PC_MinPit';       DebugOutUni7  = '(rad)';      DebugOutData(7)  = LocalVar%PC_MinPit
         DebugOutStr8  = 'SS_dOmF';         DebugOutUni8  = '(rad/s)';    DebugOutData(8)  = LocalVar%SS_DelOmegaF
-        DebugOutStr9  = 'WE_Pitch';        DebugOutUni8  = '(rad)';      DebugOutData(9)  = DebugVar%WE_Pitch
+        DebugOutStr9  = 'WE_b';            DebugOutUni9  = '(deg)';      DebugOutData(9)  = DebugVar%WE_b
+        DebugOutStr10  = 'WE_t';            DebugOutUni10  = '(Nm)';      DebugOutData(10)  = DebugVar%WE_t
+        DebugOutStr11  = 'WE_w';            DebugOutUni11  = '(rad/s)';      DebugOutData(11)  = DebugVar%WE_w
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
         DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
-                                                DebugOutStr9]
+                                                DebugOutStr9, DebugOutStr10, DebugOutStr11]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
-                                                DebugOutUni9]
+                                                DebugOutUni9, DebugOutUni10, DebugOutUni11]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -471,7 +471,7 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 11
+        nDebugOuts = 12
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         DebugOutStr1  = 'FA_AccF';         DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
@@ -485,15 +485,16 @@ CONTAINS
         DebugOutStr9  = 'WE_b';            DebugOutUni9  = '(deg)';      DebugOutData(9)  = DebugVar%WE_b
         DebugOutStr10  = 'WE_t';            DebugOutUni10  = '(Nm)';      DebugOutData(10)  = DebugVar%WE_t
         DebugOutStr11  = 'WE_w';            DebugOutUni11  = '(rad/s)';      DebugOutData(11)  = DebugVar%WE_w
+        DebugOutStr12  = 'WE_D';            DebugOutUni12  = '()';      DebugOutData(12)  = DebugVar%WE_D
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
         DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
-                                                DebugOutStr9, DebugOutStr10, DebugOutStr11]
+                                                DebugOutStr9, DebugOutStr10, DebugOutStr11, DebugOutStr12]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
-                                                DebugOutUni9, DebugOutUni10, DebugOutUni11]
+                                                DebugOutUni9, DebugOutUni10, DebugOutUni11, DebugOutUni12]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -219,7 +219,9 @@ END TYPE PerformanceData
 
 TYPE, PUBLIC :: DebugVariables
     REAL(4)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(4)                             :: WE_Pitch                       ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_b                       ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_w                       ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_t                      ! Torque that WSE uses, for debug purposes [-]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -215,6 +215,7 @@ END TYPE PerformanceData
 
 TYPE, PUBLIC :: DebugVariables
     REAL(4)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_Pitch                       ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -222,6 +222,7 @@ TYPE, PUBLIC :: DebugVariables
     REAL(4)                             :: WE_b                       ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
     REAL(4)                             :: WE_w                       ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
     REAL(4)                             :: WE_t                      ! Torque that WSE uses, for debug purposes [-]
+    REAL(4)                             :: WE_D                      ! Torque that WSE uses, for debug purposes [-]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types


### PR DESCRIPTION
Major Changes:
- Set minimum limit of pitch control integrator to the lower pitch limit defined by the pitch saturator, which reduces a small amount of windup time and reduces maximum generator speeds and load transients

Minor Changes
- Force Nacelle IMU filter output to start at 0 and add high pass filter to make floating pitch control zero-mean.  Results in little change in performance, but more understandable pitch input components.
- Update debug output to <root name>.RO.out and add signals to debug output
