### PR TITLE
Wind speed estimator and precision updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
-project(ROSCO VERSION 2.0.3 LANGUAGES Fortran)
+project(ROSCO VERSION 2.0.4 LANGUAGES Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -187,16 +187,16 @@ CONTAINS
                 
                 ! Update Jacobian
                 F(1,1) = A_op
-                F(1,2) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                F(2,2) = PI * v_m/(2.0*L)
-                F(2,3) = PI * v_t/(2.0*L)
-
+                F(1,2) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * 1/om_r * 3.0 * Cp_op * v_h**2.0
+                F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * 1/om_r * 3.0 * Cp_op * v_h**2.0
+                F(2,2) = - PI * v_m/(2.0*L)
+                F(2,3) = - PI * v_t/(2.0*L)
+                
                 ! Update process noise covariance
                 Q(1,1) = 0.00001
                 Q(2,2) =(PI * (v_m**3.0) * (Ti**2.0)) / L
                 Q(3,3) = (2.0**2.0)/600.0
-
+                
                 ! Prediction update
                 Tau_r = AeroDynTorque(LocalVar,CntrPar,PerfData)
                 a = PI * v_m/(2.0*L)

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -132,14 +132,14 @@ CONTAINS
         REAL(8)                 :: a                ! wind variance
         REAL(8)                 :: lambda           ! tip-speed-ratio [rad]
         !           - Covariance matrices
-        REAL(8), DIMENSION(2,2)         :: F        ! First order system jacobian 
-        REAL(8), DIMENSION(2,2), SAVE   :: P        ! Covariance estiamte 
-        REAL(8), DIMENSION(1,2)         :: H        ! Output equation jacobian 
-        REAL(8), DIMENSION(2,1), SAVE   :: xh       ! Estimated state matrix
-        REAL(8), DIMENSION(2,1)         :: dxh      ! Estimated state matrix deviation from previous timestep
-        REAL(8), DIMENSION(2,2)         :: Q        ! Process noise covariance matrix
+        REAL(8), DIMENSION(3,3)         :: F        ! First order system jacobian 
+        REAL(8), DIMENSION(3,3), SAVE   :: P        ! Covariance estiamte 
+        REAL(8), DIMENSION(1,3)         :: H        ! Output equation jacobian 
+        REAL(8), DIMENSION(3,1), SAVE   :: xh       ! Estimated state matrix
+        REAL(8), DIMENSION(3,1)         :: dxh      ! Estimated state matrix deviation from previous timestep
+        REAL(8), DIMENSION(3,3)         :: Q        ! Process noise covariance matrix
         REAL(8), DIMENSION(1,1)         :: S        ! Innovation covariance 
-        REAL(8), DIMENSION(2,1), SAVE   :: K        ! Kalman gain matrix
+        REAL(8), DIMENSION(3,1), SAVE   :: K        ! Kalman gain matrix
         REAL(8)                         :: R_m      ! Measurement noise covariance [(rad/s)^2]
         
         REAL(8), DIMENSION(3,1), SAVE   :: B
@@ -162,19 +162,19 @@ CONTAINS
             L = 6.0 * CntrPar%WE_BladeRadius
             Ti = 0.18
             R_m = 0.02
-            H = RESHAPE((/1.0 , 0.0/),(/1,2/))
+            H = RESHAPE((/1.0 , 0.0 , 0.0/),(/1,3/))
             ! Define matrices to be filled
-            F = RESHAPE((/0.0, 0.0, 0.0, 0.0/),(/2,2/))
-            Q = RESHAPE((/0.0, 0.0, 0.0, 0.0/),(/2,2/))
+            F = RESHAPE((/0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0/),(/3,3/))
+            Q = RESHAPE((/0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0/),(/3,3/))
             IF (LocalVar%iStatus == 0) THEN
                 ! Initialize recurring values
                 om_r = LocalVar%RotSpeedF
-                ! v_t = 0.0
-                ! v_m = LocalVar%HorWindV
+                v_t = 0.0
+                v_m = LocalVar%HorWindV
                 v_h = LocalVar%HorWindV
-                xh = RESHAPE((/om_r, v_h/),(/2,1/))
-                P = RESHAPE((/0.01, 0.0, 0.0, 0.01/),(/2,2/))
-                K = RESHAPE((/0.0,0.0,0.0/),(/2,1/))
+                xh = RESHAPE((/om_r, v_t, v_m/),(/3,1/))
+                P = RESHAPE((/0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 1.0/),(/3,3/))
+                K = RESHAPE((/0.0,0.0,0.0/),(/3,1/))
                 
             ELSE
                 ! Find estimated operating Cp and system pole
@@ -188,21 +188,21 @@ CONTAINS
                 ! Update Jacobian
                 F(1,1) = A_op
                 F(1,2) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                ! F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                F(2,2) = PI * v_h/(2.0*L)
-                ! F(2,3) = PI * v_t/(2.0*L)
+                F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
+                F(2,2) = PI * v_m/(2.0*L)
+                F(2,3) = PI * v_t/(2.0*L)
 
                 ! Update process noise covariance
                 Q(1,1) = 0.00001
-                Q(2,2) =(PI * (v_h**3.0) * (Ti**2.0)) / L + (2.0**2.0)/600.0
-                ! Q(3,3) = (2.0**2.0)/600.0
+                Q(2,2) =(PI * (v_m**3.0) * (Ti**2.0)) / L
+                Q(3,3) = (2.0**2.0)/600.0
 
                 ! Prediction update
                 Tau_r = AeroDynTorque(LocalVar,CntrPar,PerfData)
-                a = PI * v_h/(2.0*L)
+                a = PI * v_m/(2.0*L)
                 dxh(1,1) = 1.0/CntrPar%WE_Jtot * (Tau_r - CntrPar%WE_GearboxRatio * LocalVar%VS_LastGenTrqF)
-                dxh(2,1) = -a*v_h
-                ! dxh(3,1) = 0.0
+                dxh(2,1) = -a*v_t
+                dxh(3,1) = 0.0
                 
                 xh = xh + LocalVar%DT * dxh ! state update
                 P = P + LocalVar%DT*(MATMUL(F,P) + MATMUL(P,TRANSPOSE(F)) + Q - MATMUL(K * R_m, TRANSPOSE(K))) 
@@ -216,11 +216,10 @@ CONTAINS
                 
                 ! Wind Speed Estimate
                 om_r = xh(1,1)
-                v_h = xh(2,1)
-                ! v_m = xh(3,1)
-                ! v_h = v_t + v_m
-                ! LocalVar%WE_Vw = v_m + v_t
-                LocalVar%WE_Vw = V_h
+                v_t = xh(2,1)
+                v_m = xh(3,1)
+                v_h = v_t + v_m
+                LocalVar%WE_Vw = v_m + v_t
 
             ENDIF
             ! Debug Outputs

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -290,8 +290,12 @@ CONTAINS
 
         LocalVar%FA_AccHPF = HPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%FA_HPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instHPF)
         
-        ! Wind Speed Estimator
-        LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw,LocalVar%DT,0.21D0,0.7D0,LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ! Filter Wind Speed Estimator Signal
+        IF (CntrPar%F_LPFType == 1) THEN
+            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ELSE
+            LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ENDIF 
 
         ! Control commands (used by WSE, mostly)
         LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7D0, LocalVar%iStatus, .FALSE., objInst%instSecLPF)

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -292,7 +292,7 @@ CONTAINS
         
         ! Filter Wind Speed Estimator Signal
         IF (CntrPar%F_LPFType == 1) THEN
-            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.2094D0, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         ELSE
             LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         ENDIF 

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -473,7 +473,7 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 20
+        nDebugOuts = 18
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         ! Filters
@@ -495,10 +495,8 @@ CONTAINS
         DebugOutStr14  = 'WE_w';         DebugOutUni14  = '(rad/s)';   DebugOutData(14)  = DebugVar%WE_w
         DebugOutStr15  = 'WE_Vm';        DebugOutUni15  = '(m/s)';     DebugOutData(15)  = DebugVar%WE_Vm
         DebugOutStr16  = 'WE_Vt';        DebugOutUni16  = '(m/s)';     DebugOutData(16)  = DebugVar%WE_Vt
-        DebugOutStr17  = 'WE_Cp';        DebugOutUni17  = '(-)';       DebugOutData(17)  = DebugVar%WE_Cp
-        DebugOutStr18  = 'WE_lambda';    DebugOutUni18  = '(rad/s)';   DebugOutData(18)  = DebugVar%WE_lambda
-        DebugOutStr19  = 'WE_F12';       DebugOutUni19  = '(-)';       DebugOutData(19)  = DebugVar%WE_F12
-        DebugOutStr20  = 'WE_F13';       DebugOutUni20  = '(-)';       DebugOutData(20)  = DebugVar%WE_F13
+        DebugOutStr17  = 'WE_lambda';    DebugOutUni17  = '(rad/s)';   DebugOutData(17)  = DebugVar%WE_lambda
+        DebugOutStr18  = 'WE_Cp';        DebugOutUni18  = '(-)';       DebugOutData(18)  = DebugVar%WE_Cp
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
@@ -506,12 +504,12 @@ CONTAINS
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
                                                 DebugOutStr9, DebugOutStr10, DebugOutStr11, DebugOutStr12, &
                                                 DebugOutStr13, DebugOutStr14, DebugOutStr15, DebugOutStr16, &
-                                                DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20]
+                                                DebugOutStr17, DebugOutStr18]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
                                                 DebugOutUni9, DebugOutUni10, DebugOutUni11, DebugOutUni12, &
                                                 DebugOutUni13, DebugOutUni14, DebugOutUni15, DebugOutUni1, &
-                                                DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20]
+                                                DebugOutUni17, DebugOutUni18]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL
@@ -523,7 +521,7 @@ CONTAINS
                 WRITE (UnDb,'(99(a10,TR5:))') '(sec)',  DebugOutUnits
             END IF
             
-            IF (CntrPar%LoggingLevel > 1) THEN
+            IF (CntrPar%LoggingLevel > 1) THEN 
                 OPEN(unit=UnDb2, FILE='DEBUG2.dbg')
                 WRITE(UnDb2,'(/////)')
                 WRITE(UnDb2,'(A,85("'//Tab//'AvrSWAP(",I2,")"))')  'LocalVar%Time ', (i,i=1,85)

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -216,16 +216,15 @@ TYPE, PUBLIC :: PerformanceData
     REAL(8), DIMENSION(:,:), ALLOCATABLE    :: Cq_mat
 END TYPE PerformanceData
 
-TYPE, PUBLIC :: DebugVariables
-    REAL(8)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_b                         ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_w                         ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_t                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_Vm                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_Vt                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_lambda                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_F12                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_F13                         ! Torque that WSE uses, for debug purposes [-]
+TYPE, PUBLIC :: DebugVariables                                          
+! Variables used for debug purposes
+    REAL(8)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_b                         ! Pitch that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_w                         ! Rotor Speed that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_t                         ! Torque that WSE uses[-]
+    REAL(8)                             :: WE_Vm                        ! Mean wind speed component in WSE [m/s]
+    REAL(8)                             :: WE_Vt                        ! Turbulent wind speed component in WSE [m/s]
+    REAL(8)                             :: WE_lambda                    ! TSR in WSE [rad]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -548,8 +548,6 @@ CONTAINS
                      'https://github.com/NREL/ROSCO                                                 '//NEW_LINE('A')// &
                      '------------------------------------------------------------------------------'
 
-                ! print *, 'Version 1.0.1: pretty debug'
-
             CALL ReadControlParameterFileSub(CntrPar, accINFILE, NINT(avrSWAP(50)))
 
             IF (CntrPar%WE_Mode > 0) THEN
@@ -559,11 +557,7 @@ CONTAINS
             LocalVar%TestType = 0
         
             ! Initialize the SAVED variables:
-
-            ! DO K = 1,LocalVar%NumBl
             LocalVar%PitCom = LocalVar%BlPitch ! This will ensure that the variable speed controller picks the correct control region and the pitch controller picks the correct gain on the first call
-            ! END DO
-            
             LocalVar%Y_AccErr = 0.0  ! This will ensure that the accumulated yaw error starts at zero
             LocalVar%Y_YawEndT = -1.0 ! This will ensure that the initial yaw end time is lower than the actual time to prevent initial yawing
             

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -567,8 +567,8 @@ CONTAINS
             LocalVar%Y_AccErr = 0.0  ! This will ensure that the accumulated yaw error starts at zero
             LocalVar%Y_YawEndT = -1.0 ! This will ensure that the initial yaw end time is lower than the actual time to prevent initial yawing
             
-            ! Wind speed estimator initialization, we always assume an initial wind speed of 10 m/s
-            LocalVar%WE_Vw = 10
+            ! Wind speed estimator initialization
+            LocalVar%WE_Vw = LocalVar%HorWindV
             LocalVar%WE_VwI = LocalVar%WE_Vw - CntrPar%WE_Gamma*LocalVar%RotSpeed
             
             ! Setpoint Smoother initialization to zero


### PR DESCRIPTION
A few big updates here and a number of small ones:

Main updates:
- Moved everything to double precision. This does not seem to have a significant impact on simulation time. The primary reason for doing this is because of the filter parameters (especially the low-pass filters). Compiling in double precision reduces sensitivity of the parameters to changes in DT, and resolves issues with running ROSCO in OpenFAST simulations with small timesteps (e.g. when running beamdyn with DT=0.0001). 
- Fixed some bugs in the Jacobian calculation in the wind speed estimator. One thing to note: F(1,2) and F(1,3) should theoretically have an additional term in them that includes some partial derivatives w.r.t. wind speed. These partials are ~O(1e-6) times Cp*v^2, so we are leaving them out. Otherwise, there was a sign error that prevented the mean wind speed state from evolving appropriately. This was seldom seen as a problem in 10 minute simulations, but will probably help some fringe cases and longer simulations. 

Minor changes:
- Some of the filter parameters were updated. I think these are better now - hopefully users agree. If there is some quantitative evidence to show otherwise, then we can certainly change this back. Notably, the wind speed estimator is now filtered by the primary corner frequency rather than a fixed value. [Seen in this commit](https://github.com/NREL/ROSCO/commit/229c2812d79572c00417d32921808c5b518ebb42). 
