### PR TITLE
Updated debug, double precision, wind speed estimator fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,10 @@ project(ROSCO VERSION 2.0.1 LANGUAGES Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 
-# Sets the optimization level to -O2 and includes -g 
-set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+if (NOT CMAKE_BUILD_TYPE)
+  # Sets the optimization level to -O2 and includes -g for debugging
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the build type: Debug RelWithDebInfo Release" FORCE)
+endif()
 
 message(STATUS "CMAKE_Fortran_COMPILER_ID = ${CMAKE_Fortran_COMPILER_ID}")
 if(APPLE OR UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
-project(ROSCO VERSION 2.0.4 LANGUAGES Fortran)
+project(ROSCO VERSION 2.1.0 LANGUAGES Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
-project(ROSCO VERSION 2.0.1 LANGUAGES Fortran)
+project(ROSCO VERSION 2.0.3 LANGUAGES Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 
@@ -12,9 +12,9 @@ message(STATUS "CMAKE_Fortran_COMPILER_ID = ${CMAKE_Fortran_COMPILER_ID}")
 if(APPLE OR UNIX)
   # Enable .dll export
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DIMPLICIT_DLLEXPORT ")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DIMPLICIT_DLLEXPORT -r8 -double_size 64")
   else()
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DIMPLICIT_DLLEXPORT -ffree-line-length-0")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DIMPLICIT_DLLEXPORT -ffree-line-length-0 -fdefault-real-8 -fdefault-double-8")
   endif()
 elseif(WIN32 AND MINGW)
   # Ensure static linking to avoid requiring Fortran runtime dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
-project(ROSCO VERSION 2.0.3 LANGUAGES Fortran)
+project(ROSCO VERSION 2.0.4 LANGUAGES Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,4 +31,10 @@ set(SOURCES
 )
 
 add_library(discon SHARED ${SOURCES})
-# add_library(discon_yawAPI SHARED ${SOURCES})
+
+install(TARGETS discon
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
+  RUNTIME DESTINATION lib
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,17 @@ set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 # Sets the optimization level to -O2 and includes -g 
 set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 
-# Enable .dll export
+message(STATUS "CMAKE_Fortran_COMPILER_ID = ${CMAKE_Fortran_COMPILER_ID}")
 if(APPLE OR UNIX)
+  # Enable .dll export
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DIMPLICIT_DLLEXPORT ")
   else()
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DIMPLICIT_DLLEXPORT -ffree-line-length-0")
   endif()
+elseif(WIN32 AND MINGW)
+  # Ensure static linking to avoid requiring Fortran runtime dependencies
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-0 -static-libgcc -static-libgfortran -static")
 endif()
 
 set(SOURCES
@@ -27,3 +31,4 @@ set(SOURCES
 )
 
 add_library(discon SHARED ${SOURCES})
+# add_library(discon_yawAPI SHARED ${SOURCES})

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -10,10 +10,10 @@
 ! specific language governing permissions and limitations under the License.
 
 MODULE Constants
-    REAL(4), PARAMETER          :: RPS2RPM = 9.5492966                  ! Factor to convert radians per second to revolutions per minute.
-    REAL(4), PARAMETER          :: R2D = 57.295780                      ! Factor to convert radians to degrees.
-    REAL(4), PARAMETER          :: D2R = 0.0175                         ! Factor to convert degrees to radians.
-    REAL(4), PARAMETER          :: PI = 3.14159265359                   ! Mathematical constant pi
+    REAL(8), PARAMETER          :: RPS2RPM = 9.5492966                  ! Factor to convert radians per second to revolutions per minute.
+    REAL(8), PARAMETER          :: R2D = 57.295780                      ! Factor to convert radians to degrees.
+    REAL(8), PARAMETER          :: D2R = 0.0175                         ! Factor to convert degrees to radians.
+    REAL(8), PARAMETER          :: PI = 3.14159265359                   ! Mathematical constant pi
     INTEGER(4), PARAMETER       :: NP_1 = 1                             ! First rotational harmonic
     INTEGER(4), PARAMETER       :: NP_2 = 2                             ! Second rotational harmonic
 END MODULE Constants

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -179,9 +179,9 @@ CONTAINS
                 ! Find estimated operating Cp and system pole
                 A_op = interp1d(CntrPar%WE_FOPoles_v,CntrPar%WE_FOPoles,v_h)
 
-                ! Find Cp
-                lambda = LocalVar%RotSpeedF * CntrPar%WE_BladeRadius/v_h
-                Cp_op = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%PC_PitComTF*R2D, lambda)
+                ! TEST INTERP2D
+                lambda = LocalVar%RotSpeed * CntrPar%WE_BladeRadius/v_h
+                Cp_op = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%BlPitch(1)*R2D, lambda )
                 Cp_op = max(0.0,Cp_op)
                 
                 ! Update Jacobian

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -103,11 +103,11 @@ CONTAINS
         END IF
     END SUBROUTINE StateMachine
 !-------------------------------------------------------------------------------------------------------------------------------
-    SUBROUTINE WindSpeedEstimator(LocalVar, CntrPar, objInst, PerfData)
+    SUBROUTINE WindSpeedEstimator(LocalVar, CntrPar, objInst, PerfData, DebugVar)
     ! Wind Speed Estimator estimates wind speed at hub height. Currently implements two types of estimators
     !       WE_Mode = 0, Filter hub height wind speed as passed from servodyn using first order low pass filter with 1Hz cornering frequency
     !       WE_Mode = 1, Use Inversion and Inveriance filter as defined by Ortege et. al. 
-        USE ROSCO_Types, ONLY : LocalVariables, ControlParameters, ObjectInstances, PerformanceData
+        USE ROSCO_Types, ONLY : LocalVariables, ControlParameters, ObjectInstances, PerformanceData, DebugVariables
         IMPLICIT NONE
     
         ! Inputs
@@ -115,6 +115,7 @@ CONTAINS
         TYPE(LocalVariables),       INTENT(INOUT)       :: LocalVar 
         TYPE(ObjectInstances),      INTENT(INOUT)       :: objInst
         TYPE(PerformanceData),      INTENT(INOUT)       :: PerfData
+        TYPE(DebugVariables),       INTENT(INOUT)       :: DebugVar
         ! Allocate Variables
         REAL(4)                 :: F_WECornerFreq   ! Corner frequency (-3dB point) for first order low pass filter for measured hub height wind speed [Hz]
 
@@ -216,7 +217,7 @@ CONTAINS
                 LocalVar%WE_Vw = v_m + v_t
 
                 ! Debug Outputs
-                LocalVar%WE_Cp = Cp_op
+                DebugVar%WE_Cp = Cp_op
             ENDIF
 
         ELSE        

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -88,10 +88,10 @@ CONTAINS
             ELSE
                 IF (LocalVar%GenArTq >= CntrPar%VS_MaxOMTq*1.01) THEN       ! Region 2 1/2 - active PI torque control
                     LocalVar%VS_State = 3                 
-                ELSEIF (LocalVar%GenSpeedF < CntrPar%VS_RefSpd)  THEN       ! Region 2 - optimal torque is proportional to the square of the generator speed
-                
+                ELSEIF ((LocalVar%GenSpeedF < CntrPar%VS_RefSpd) .AND. &
+                        (LocalVar%GenBrTq >= CntrPar%VS_MinOMTq)) THEN       ! Region 2 - optimal torque is proportional to the square of the generator speed
                     LocalVar%VS_State = 2
-                ELSEIF (LocalVar%GenBrTq <= CntrPar%VS_MinOMTq*0.99) THEN   ! Region 1 1/2
+                ELSEIF (LocalVar%GenBrTq < CntrPar%VS_MinOMTq) THEN   ! Region 1 1/2
                 
                     LocalVar%VS_State = 1
                 ELSE                                                        ! Error state, Debug

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -150,13 +150,13 @@ CONTAINS
         IF (CntrPar%WE_Mode == 1) THEN      
             LocalVar%WE_VwIdot = CntrPar%WE_Gamma/CntrPar%WE_Jtot*(LocalVar%VS_LastGenTrq*CntrPar%WE_GearboxRatio - AeroDynTorque(LocalVar, CntrPar, PerfData))
             LocalVar%WE_VwI = LocalVar%WE_VwI + LocalVar%WE_VwIdot*LocalVar%DT
-            LocalVar%WE_Vw = LocalVar%WE_VwI + CntrPar%WE_Gamma*LocalVar%RotSpeed
+            LocalVar%WE_Vw = LocalVar%WE_VwI + CntrPar%WE_Gamma*LocalVar%RotSpeedF
 
         ! Extended Kalman Filter (EKF) implementation
         ELSEIF (CntrPar%WE_Mode == 2) THEN
             ! Define contant values
-            L = 4.0 * CntrPar%WE_BladeRadius
-            Ti = 0.2
+            L = 6.0 * CntrPar%WE_BladeRadius
+            Ti = 0.18
             R_m = 0.02
             H = RESHAPE((/1.0 , 0.0 , 0.0/),(/1,3/))
             ! Define matrices to be filled
@@ -164,7 +164,7 @@ CONTAINS
             Q = RESHAPE((/0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0/),(/3,3/))
             IF (LocalVar%iStatus == 0) THEN
                 ! Initialize recurring values
-                om_r = LocalVar%RotSpeed
+                om_r = LocalVar%RotSpeedF
                 v_t = 0.0
                 v_m = LocalVar%HorWindV
                 v_h = LocalVar%HorWindV
@@ -176,10 +176,9 @@ CONTAINS
                 ! Find estimated operating Cp and system pole
                 A_op = interp1d(CntrPar%WE_FOPoles_v,CntrPar%WE_FOPoles,v_h)
 
-                ! TEST INTERP2D
-                lambda = LocalVar%RotSpeed * CntrPar%WE_BladeRadius/v_h
-                DebugVar%WE_Pitch = LocalVar%BlPitch(1)
-                Cp_op = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%BlPitch(1)*R2D, lambda )
+                ! Find Cp
+                lambda = LocalVar%RotSpeedF * CntrPar%WE_BladeRadius/v_h
+                Cp_op = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%PC_PitComTF*R2D, lambda)
                 Cp_op = max(0.0,Cp_op)
                 
                 ! Update Jacobian
@@ -197,7 +196,7 @@ CONTAINS
                 ! Prediction update
                 Tau_r = AeroDynTorque(LocalVar,CntrPar,PerfData)
                 a = PI * v_m/(2.0*L)
-                dxh(1,1) = 1.0/CntrPar%WE_Jtot * (Tau_r - CntrPar%WE_GearboxRatio * LocalVar%VS_LastGenTrq)
+                dxh(1,1) = 1.0/CntrPar%WE_Jtot * (Tau_r - CntrPar%WE_GearboxRatio * LocalVar%VS_LastGenTrqF)
                 dxh(2,1) = -a*v_t
                 dxh(3,1) = 0.0
                 
@@ -207,7 +206,7 @@ CONTAINS
                 ! Measurement update
                 S = MATMUL(H,MATMUL(P,TRANSPOSE(H))) + R_m        ! NJA: (H*T*H') \approx 0
                 K = MATMUL(P,TRANSPOSE(H))/S(1,1)
-                xh = xh + K*(LocalVar%GenSpeedF/CntrPar%WE_GearboxRatio - om_r)
+                xh = xh + K*(LocalVar%RotSpeedF - om_r)
                 P = MATMUL(identity(3) - MATMUL(K,H),P)
                 
                 ! Wind Speed Estimate
@@ -223,7 +222,7 @@ CONTAINS
 
         ELSE        
             ! Define Variables
-            F_WECornerFreq = 0.0333  ! Fix to 30 second time constant for now    
+            F_WECornerFreq = 0.20944  ! Fix to 30 second time constant for now    
 
             ! Filter wind speed at hub height as directly passed from OpenFAST
             LocalVar%WE_Vw = LPFilter(LocalVar%HorWindV, LocalVar%DT, F_WECornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF)
@@ -248,7 +247,7 @@ CONTAINS
         ! ------ Setpoint Smoothing ------
         IF ( CntrPar%SS_Mode == 1) THEN
             ! Find setpoint shift amount
-            DelOmega = ((LocalVar%BlPitch(1) - CntrPar%PC_MinPit)/0.524) * CntrPar%SS_VSGain - ((CntrPar%VS_RtTq - LocalVar%VS_LastGenTrq))/CntrPar%VS_RtTq * CntrPar%SS_PCGain ! Normalize to 30 degrees for now
+            DelOmega = ((LocalVar%PC_PitComT - CntrPar%PC_MinPit)/0.524) * CntrPar%SS_VSGain - ((CntrPar%VS_RtTq - LocalVar%VS_LastGenTrq))/CntrPar%VS_RtTq * CntrPar%SS_PCGain ! Normalize to 30 degrees for now
             DelOmega = DelOmega * CntrPar%PC_RefSpd
             ! Filter
             LocalVar%SS_DelOmegaF = LPFilter(DelOmega, LocalVar%DT, CntrPar%F_SSCornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF) 
@@ -273,13 +272,9 @@ CONTAINS
         REAL(4)                     :: Vhat     ! Estimated wind speed without towertop motion [m/s]
         REAL(4)                     :: Vhatf     ! 30 second low pass filtered Estimated wind speed without towertop motion [m/s]
 
-        ! Account for towertop motions in wind speed estimate
-        !       Integrate Towertop Acceleration  
-        ! dV_towertop = 
-        ! V_towertop = PIController(LocalVar%FA_Acc, 0.0, 1.0, -100.00, 100.00, LocalVar%DT, 0.0, .FALSE., objInst%instPI)
-
-        Vhat = LocalVar%WE_Vw
-        Vhatf = LPFilter(Vhat,LocalVar%DT,0.2,LocalVar%iStatus,.FALSE.,objInst%instLPF)
+        V_towertop = PIController(LocalVar%FA_Acc, 0.0, 1.0, -100.0, 100.0, LocalVar%DT, 0.0, .FALSE., objInst%instPI)
+        Vhat = LocalVar%WE_Vw_F + V_towertop
+        Vhatf = SecLPFilter(Vhat,LocalVar%DT,0.21,0.7,LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         
         ! Define minimum blade pitch angle as a function of estimated wind speed
         PitchSaturation = interp1d(CntrPar%PS_WindSpeeds, CntrPar%PS_BldPitchMin, Vhatf)

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -55,7 +55,7 @@ CONTAINS
         ! Initialize State machine if first call
         IF (LocalVar%iStatus == 0) THEN ! .TRUE. if we're on the first call to the DLL
 
-            IF (LocalVar%PitCom(1) >= CntrPar%VS_Rgn3Pitch) THEN ! We are in region 3
+            IF (LocalVar%PitCom(1) >= LocalVar%VS_Rgn3Pitch) THEN ! We are in region 3
                 IF (CntrPar%VS_ControlMode == 1) THEN ! Constant power tracking
                     LocalVar%VS_State = 5
                     LocalVar%PC_State = 1
@@ -78,14 +78,12 @@ CONTAINS
             END IF
             
             ! --- Torque control state machine ---
-            IF (LocalVar%PC_PitComT >= CntrPar%VS_Rgn3Pitch) THEN       
+            IF (LocalVar%PC_PitComT >= LocalVar%VS_Rgn3Pitch) THEN       
 
-                IF (LocalVar%PC_PitComT >= LocalVar%PC_MinPit + CntrPar%PC_Switch) THEN ! Make sure we aren't implement pitch saturation
-                    IF (CntrPar%VS_ControlMode == 1) THEN                   ! Region 3
-                        LocalVar%VS_State = 5 ! Constant power tracking
-                    ELSE 
-                        LocalVar%VS_State = 4 ! Constant torque tracking
-                    END IF
+                IF (CntrPar%VS_ControlMode == 1) THEN                   ! Region 3
+                    LocalVar%VS_State = 5 ! Constant power tracking
+                ELSE 
+                    LocalVar%VS_State = 4 ! Constant torque tracking
                 END IF
             ELSE
                 IF (LocalVar%GenArTq >= CntrPar%VS_MaxOMTq*1.01) THEN       ! Region 2 1/2 - active PI torque control

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -159,7 +159,7 @@ CONTAINS
         ! Extended Kalman Filter (EKF) implementation
         ELSEIF (CntrPar%WE_Mode == 2) THEN
             ! Define contant values
-            L = 6.0 * CntrPar%WE_BladeRadius
+            L = 2.0 * CntrPar%WE_BladeRadius
             Ti = 0.18
             R_m = 0.02
             H = RESHAPE((/1.0 , 0.0 , 0.0/),(/1,3/))
@@ -172,6 +172,7 @@ CONTAINS
                 v_t = 0.0
                 v_m = LocalVar%HorWindV
                 v_h = LocalVar%HorWindV
+                lambda = LocalVar%RotSpeed * CntrPar%WE_BladeRadius/v_h
                 xh = RESHAPE((/om_r, v_t, v_m/),(/3,1/))
                 P = RESHAPE((/0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 1.0/),(/3,3/))
                 K = RESHAPE((/0.0,0.0,0.0/),(/3,1/))
@@ -187,16 +188,16 @@ CONTAINS
                 
                 ! Update Jacobian
                 F(1,1) = A_op
-                F(1,2) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                F(2,2) = PI * v_m/(2.0*L)
-                F(2,3) = PI * v_t/(2.0*L)
-
+                F(1,2) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * 1/om_r * 3.0 * Cp_op * v_h**2.0
+                F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * 1/om_r * 3.0 * Cp_op * v_h**2.0
+                F(2,2) = - PI * v_m/(2.0*L)
+                F(2,3) = - PI * v_t/(2.0*L)
+                
                 ! Update process noise covariance
                 Q(1,1) = 0.00001
                 Q(2,2) =(PI * (v_m**3.0) * (Ti**2.0)) / L
                 Q(3,3) = (2.0**2.0)/600.0
-
+                
                 ! Prediction update
                 Tau_r = AeroDynTorque(LocalVar,CntrPar,PerfData)
                 a = PI * v_m/(2.0*L)
@@ -206,13 +207,13 @@ CONTAINS
                 
                 xh = xh + LocalVar%DT * dxh ! state update
                 P = P + LocalVar%DT*(MATMUL(F,P) + MATMUL(P,TRANSPOSE(F)) + Q - MATMUL(K * R_m, TRANSPOSE(K))) 
-
+                
                 ! Measurement update
                 S = MATMUL(H,MATMUL(P,TRANSPOSE(H))) + R_m        ! NJA: (H*T*H') \approx 0
                 K = MATMUL(P,TRANSPOSE(H))/S(1,1)
                 xh = xh + K*(LocalVar%RotSpeedF - om_r)
                 P = MATMUL(identity(3) - MATMUL(K,H),P)
-
+                
                 
                 ! Wind Speed Estimate
                 om_r = xh(1,1)
@@ -220,16 +221,12 @@ CONTAINS
                 v_m = xh(3,1)
                 v_h = v_t + v_m
                 LocalVar%WE_Vw = v_m + v_t
-
-            ENDIF
+                ENDIF
             ! Debug Outputs
             DebugVar%WE_Cp = Cp_op
             DebugVar%WE_Vm = v_m
             DebugVar%WE_Vt = v_t
             DebugVar%WE_lambda = lambda
-            DebugVar%WE_F12 = F(1,2)
-            DebugVar%WE_F13 = F(1,3)
-
         ELSE        
             ! Define Variables
             F_WECornerFreq = 0.20944  ! Fix to 30 second time constant for now    

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -178,6 +178,7 @@ CONTAINS
 
                 ! TEST INTERP2D
                 lambda = LocalVar%RotSpeed * CntrPar%WE_BladeRadius/v_h
+                DebugVar%WE_Pitch = LocalVar%BlPitch(1)
                 Cp_op = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%BlPitch(1)*R2D, lambda )
                 Cp_op = max(0.0,Cp_op)
                 

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -144,6 +144,11 @@ CONTAINS
         REAL(4), DIMENSION(3,1), SAVE   :: K        ! Kalman gain matrix
         REAL(4)                         :: R_m      ! Measurement noise covariance [(rad/s)^2]
         
+        ! ---- Debug Inputs ------
+        DebugVar%WE_b   = LocalVar%PC_PitComTF*R2D
+        DebugVar%WE_w   = LocalVar%RotSpeedF
+        DebugVar%WE_t   = LocalVar%VS_LastGenTrqF
+
         ! ---- Define wind speed estimate ---- 
         
         ! Inversion and Invariance Filter implementation

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -213,6 +213,7 @@ CONTAINS
                 K = MATMUL(P,TRANSPOSE(H))/S(1,1)
                 xh = xh + K*(LocalVar%RotSpeedF - om_r)
                 P = MATMUL(identity(3) - MATMUL(K,H),P)
+
                 
                 ! Wind Speed Estimate
                 om_r = xh(1,1)
@@ -223,6 +224,8 @@ CONTAINS
 
                 ! Debug Outputs
                 DebugVar%WE_Cp = Cp_op
+                DebugVar%WE_D = v_m
+
             ENDIF
 
         ELSE        

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -268,12 +268,10 @@ CONTAINS
         TYPE(LocalVariables), INTENT(INOUT)     :: LocalVar 
         TYPE(ObjectInstances), INTENT(INOUT)    :: objInst
         ! Allocate Variables 
-        REAL(4)                     :: V_towertop ! Estimated velocity of tower top (m/s)
         REAL(4)                     :: Vhat     ! Estimated wind speed without towertop motion [m/s]
         REAL(4)                     :: Vhatf     ! 30 second low pass filtered Estimated wind speed without towertop motion [m/s]
 
-        V_towertop = PIController(LocalVar%FA_Acc, 0.0, 1.0, -100.0, 100.0, LocalVar%DT, 0.0, .FALSE., objInst%instPI)
-        Vhat = LocalVar%WE_Vw_F + V_towertop
+        Vhat = LocalVar%WE_Vw_F
         Vhatf = SecLPFilter(Vhat,LocalVar%DT,0.21,0.7,LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         
         ! Define minimum blade pitch angle as a function of estimated wind speed

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -88,9 +88,9 @@ CONTAINS
         ! Pitch Saturation
         IF (CntrPar%PS_Mode == 1) THEN
             LocalVar%PC_MinPit = PitchSaturation(LocalVar,CntrPar,objInst)
-            LocalVar%PC_MinPit = max(LocalVar%PC_MinPit, CntrPar%PC_MinPit)
+            LocalVar%PC_MinPit = max(LocalVar%PC_MinPit, CntrPar%PC_FinePit)
         ELSE
-            LocalVar%PC_MinPit = CntrPar%PC_MinPit
+            LocalVar%PC_MinPit = CntrPar%PC_FinePit
         ENDIF
 
         ! Shutdown

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -68,7 +68,7 @@ CONTAINS
         IF (LocalVar%iStatus == 0) THEN
             LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, CntrPar%PC_FinePit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%PitCom(1), .TRUE., objInst%instPI)
         ELSE
-            LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, CntrPar%PC_FinePit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%BlPitch(1), .FALSE., objInst%instPI)
+            LocalVar%PC_PitComT = PIController(LocalVar%PC_SpdErr, LocalVar%PC_KP, LocalVar%PC_KI, LocalVar%PC_MinPit, LocalVar%PC_MaxPit, LocalVar%DT, LocalVar%BlPitch(1), .FALSE., objInst%instPI)
         END IF
         
         ! Find individual pitch control contribution

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -110,8 +110,10 @@ CONTAINS
         PitComT_Last = LocalVar%PC_PitComT
 
         ! Combine and saturate all individual pitch commands:
+        ! Filter to emulate pitch actuator
         DO K = 1,LocalVar%NumBl ! Loop through all blades, add IPC contribution and limit pitch rate
             LocalVar%PitCom(K) = LocalVar%PC_PitComT + LocalVar%IPC_PitComF(K) + LocalVar%FA_PitCom(K) 
+            ! LocalVar%PitCom(K) = SecLPFilter(LocalVar%PitCom(K), LocalVar%DT, , Damp, iStatus, reset, inst)
             LocalVar%PitCom(K) = saturate(LocalVar%PitCom(K), LocalVar%PC_MinPit, CntrPar%PC_MaxPit)                    ! Saturate the overall command using the pitch angle limits
             LocalVar%PitCom(K) = ratelimit(LocalVar%PitCom(K), LocalVar%BlPitch(K), CntrPar%PC_MinRat, CntrPar%PC_MaxRat, LocalVar%DT) ! Saturate the overall command of blade K using the pitch rate limit
         END DO

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -85,7 +85,7 @@ CONTAINS
             LocalVar%FA_PitCom = 0.0 ! THIS IS AN ARRAY!!
         ENDIF
         
-        ! Peak Shaving
+        ! Pitch Saturation
         IF (CntrPar%PS_Mode == 1) THEN
             LocalVar%PC_MinPit = PitchSaturation(LocalVar,CntrPar,objInst)
             LocalVar%PC_MinPit = max(LocalVar%PC_MinPit, CntrPar%PC_MinPit)
@@ -162,7 +162,6 @@ CONTAINS
         ! K*Omega^2 control law with PI torque control in transition regions
         ELSE
             ! Update PI loops for region 1.5 and 2.5 PI control
-            ! LocalVar%GenArTq = PIController(LocalVar%VS_SpdErrAr, CntrPar%VS_KP(1), CntrPar%VS_KI(1), CntrPar%VS_MaxOMTq, CntrPar%VS_ArSatTq, LocalVar%DT, CntrPar%VS_RtTq, .TRUE., objInst%instPI)
             LocalVar%GenArTq = PIController(LocalVar%VS_SpdErrAr, CntrPar%VS_KP(1), CntrPar%VS_KI(1), CntrPar%VS_MaxOMTq, CntrPar%VS_ArSatTq, LocalVar%DT, CntrPar%VS_MaxOMTq, .FALSE., objInst%instPI)
             LocalVar%GenBrTq = PIController(LocalVar%VS_SpdErrBr, CntrPar%VS_KP(1), CntrPar%VS_KI(1), CntrPar%VS_MinTq, CntrPar%VS_MinOMTq, LocalVar%DT, CntrPar%VS_MinOMTq, .FALSE., objInst%instPI)
             

--- a/src/DISCON.F90
+++ b/src/DISCON.F90
@@ -62,16 +62,15 @@ RootName = TRANSFER(avcOUTNAME, RootName)
 ! Read avrSWAP array into derived types/variables
 CALL ReadAvrSWAP(avrSWAP, LocalVar)
 CALL SetParameters(avrSWAP, aviFAIL, accINFILE, ErrMsg, SIZE(avcMSG), CntrPar, LocalVar, objInst, PerfData)
-CALL PreFilterMeasuredSignals(CntrPar, LocalVar, objInst)
 
 IF ((LocalVar%iStatus >= 0) .AND. (aviFAIL >= 0))  THEN  ! Only compute control calculations if no error has occurred and we are not on the last time step
+    CALL PreFilterMeasuredSignals(CntrPar, LocalVar, objInst)
     CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
     
     CALL StateMachine(CntrPar, LocalVar)
     CALL WindSpeedEstimator(LocalVar, CntrPar, objInst, PerfData, DebugVar)
-    
     CALL SetpointSmoother(LocalVar, CntrPar, objInst)
-
+    CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
     CALL VariableSpeedControl(avrSWAP, CntrPar, LocalVar, objInst)
     CALL PitchControl(avrSWAP, CntrPar, LocalVar, objInst)
     CALL YawRateControl(avrSWAP, CntrPar, LocalVar, objInst)

--- a/src/DISCON.F90
+++ b/src/DISCON.F90
@@ -55,6 +55,7 @@ TYPE(ObjectInstances), SAVE           :: objInst
 TYPE(PerformanceData), SAVE           :: PerfData
 TYPE(DebugVariables), SAVE            :: DebugVar
 
+RootName = TRANSFER(avcOUTNAME, RootName)
 !------------------------------------------------------------------------------------------------------------------------------
 ! Main control calculations
 !------------------------------------------------------------------------------------------------------------------------------

--- a/src/DISCON.F90
+++ b/src/DISCON.F90
@@ -53,6 +53,7 @@ TYPE(ControlParameters), SAVE         :: CntrPar
 TYPE(LocalVariables), SAVE            :: LocalVar
 TYPE(ObjectInstances), SAVE           :: objInst
 TYPE(PerformanceData), SAVE           :: PerfData
+TYPE(DebugVariables), SAVE            :: DebugVar
 
 !------------------------------------------------------------------------------------------------------------------------------
 ! Main control calculations
@@ -66,7 +67,7 @@ IF ((LocalVar%iStatus >= 0) .AND. (aviFAIL >= 0))  THEN  ! Only compute control 
     CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
     
     CALL StateMachine(CntrPar, LocalVar)
-    CALL WindSpeedEstimator(LocalVar, CntrPar, objInst, PerfData)
+    CALL WindSpeedEstimator(LocalVar, CntrPar, objInst, PerfData, DebugVar)
     
     CALL SetpointSmoother(LocalVar, CntrPar, objInst)
 
@@ -75,7 +76,7 @@ IF ((LocalVar%iStatus >= 0) .AND. (aviFAIL >= 0))  THEN  ! Only compute control 
     CALL YawRateControl(avrSWAP, CntrPar, LocalVar, objInst)
     CALL FlapControl(avrSWAP, CntrPar, LocalVar, objInst)
     
-    CALL Debug(LocalVar, CntrPar, avrSWAP, RootName, SIZE(avcOUTNAME))
+    CALL Debug(LocalVar, CntrPar, DebugVar, avrSWAP, RootName, SIZE(avcOUTNAME))
 END IF
 
 avcMSG = TRANSFER(TRIM(ErrMsg)//C_NULL_CHAR, avcMSG, SIZE(avcMSG))

--- a/src/DISCON.F90
+++ b/src/DISCON.F90
@@ -62,9 +62,9 @@ RootName = TRANSFER(avcOUTNAME, RootName)
 ! Read avrSWAP array into derived types/variables
 CALL ReadAvrSWAP(avrSWAP, LocalVar)
 CALL SetParameters(avrSWAP, aviFAIL, accINFILE, ErrMsg, SIZE(avcMSG), CntrPar, LocalVar, objInst, PerfData)
+CALL PreFilterMeasuredSignals(CntrPar, LocalVar, objInst)
 
 IF ((LocalVar%iStatus >= 0) .AND. (aviFAIL >= 0))  THEN  ! Only compute control calculations if no error has occurred and we are not on the last time step
-    CALL PreFilterMeasuredSignals(CntrPar, LocalVar, objInst)
     CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
     
     CALL StateMachine(CntrPar, LocalVar)
@@ -72,7 +72,7 @@ IF ((LocalVar%iStatus >= 0) .AND. (aviFAIL >= 0))  THEN  ! Only compute control 
     CALL SetpointSmoother(LocalVar, CntrPar, objInst)
     CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
     CALL VariableSpeedControl(avrSWAP, CntrPar, LocalVar, objInst)
-    CALL PitchControl(avrSWAP, CntrPar, LocalVar, objInst)
+    CALL PitchControl(avrSWAP, CntrPar, LocalVar, objInst, DebugVar)
     CALL YawRateControl(avrSWAP, CntrPar, LocalVar, objInst)
     CALL FlapControl(avrSWAP, CntrPar, LocalVar, objInst)
     

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -273,7 +273,7 @@ CONTAINS
         ! Filtering the tower fore-aft acceleration signal 
         IF (CntrPar%Fl_Mode == 1) THEN
             LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
-            LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_FlCornerFreq/3, LocalVar%iStatus, .FALSE., objInst%instHPF) 
+            ! LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_FlCornerFreq/3, LocalVar%iStatus, .FALSE., objInst%instHPF) 
             ! LocalVar%NacIMU_FA_AccF = NotchFilterSlopes(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instNotchSlopes) ! Fixed Damping
             IF (CntrPar%F_NotchType >= 2) THEN
                 LocalVar%NACIMU_FA_AccF = NotchFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_NotchCornerFreq, CntrPar%F_NotchBetaNumDen(1), CntrPar%F_NotchBetaNumDen(2), LocalVar%iStatus, .FALSE., objInst%instNotch) ! Fixed Damping

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -273,6 +273,7 @@ CONTAINS
         ! Filtering the tower fore-aft acceleration signal 
         IF (CntrPar%Fl_Mode == 1) THEN
             LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+            LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_FlCornerFreq/3, LocalVar%iStatus, .FALSE., objInst%instHPF) 
             ! LocalVar%NacIMU_FA_AccF = NotchFilterSlopes(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instNotchSlopes) ! Fixed Damping
             IF (CntrPar%F_NotchType >= 2) THEN
                 LocalVar%NACIMU_FA_AccF = NotchFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_NotchCornerFreq, CntrPar%F_NotchBetaNumDen(1), CntrPar%F_NotchBetaNumDen(2), LocalVar%iStatus, .FALSE., objInst%instNotch) ! Fixed Damping

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -274,8 +274,13 @@ CONTAINS
 
         ! Filtering the tower fore-aft acceleration signal 
         IF (CntrPar%Fl_Mode == 1) THEN
-            LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
-            ! LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_FlCornerFreq/3, LocalVar%iStatus, .FALSE., objInst%instHPF) 
+            ! Force to start at 0
+            IF (LocalVar%iStatus == 0) THEN
+                LocalVar%NacIMU_FA_AccF = SecLPFilter(0., LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+            ELSE
+                LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+            ENDIF
+                LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, 0.0167, LocalVar%iStatus, .FALSE., objInst%instHPF) 
             ! LocalVar%NacIMU_FA_AccF = NotchFilterSlopes(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instNotchSlopes) ! Fixed Damping
             IF (CntrPar%F_NotchType >= 2) THEN
                 LocalVar%NACIMU_FA_AccF = NotchFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_NotchCornerFreq, CntrPar%F_NotchBetaNumDen(1), CntrPar%F_NotchBetaNumDen(2), LocalVar%iStatus, .FALSE., objInst%instNotch) ! Fixed Damping

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -290,8 +290,12 @@ CONTAINS
 
         LocalVar%FA_AccHPF = HPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%FA_HPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instHPF)
         
-        ! Wind Speed Estimator
-        LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw,LocalVar%DT,0.21D0,0.7D0,LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ! Filter Wind Speed Estimator Signal
+        IF (CntrPar%F_LPFType == 1) THEN
+            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.2094D0, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ELSE
+            LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ENDIF 
 
         ! Control commands (used by WSE, mostly)
         LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7D0, LocalVar%iStatus, .FALSE., objInst%instSecLPF)

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -31,21 +31,21 @@ CONTAINS
     !                               Continuous Time Form:   H(s) = CornerFreq/(1 + CornerFreq)
     !                               Discrete Time Form:     H(z) = (b1z + b0) / (a1*z + a0)
     !
-        REAL(4), INTENT(IN)         :: InputSignal
-        REAL(4), INTENT(IN)         :: DT                       ! time step [s]
-        REAL(4), INTENT(IN)         :: CornerFreq               ! corner frequency [rad/s]
+        REAL(8), INTENT(IN)         :: InputSignal
+        REAL(8), INTENT(IN)         :: DT                       ! time step [s]
+        REAL(8), INTENT(IN)         :: CornerFreq               ! corner frequency [rad/s]
         INTEGER(4), INTENT(IN)      :: iStatus                  ! A status flag set by the simulation as follows: 0 if this is the first call, 1 for all subsequent time steps, -1 if this is the final call at the end of the simulation.
         INTEGER(4), INTENT(INOUT)   :: inst                     ! Instance number. Every instance of this function needs to have an unique instance number to ensure instances don't influence each other.
         LOGICAL(4), INTENT(IN)      :: reset                    ! Reset the filter to the input signal
 
             ! Local
-        REAL(4), DIMENSION(99), SAVE    :: a1                   ! Denominator coefficient 1
-        REAL(4), DIMENSION(99), SAVE    :: a0                   ! Denominator coefficient 0
-        REAL(4), DIMENSION(99), SAVE    :: b1                    ! Numerator coefficient 1
-        REAL(4), DIMENSION(99), SAVE    :: b0                    ! Numerator coefficient 0 
+        REAL(8), DIMENSION(99), SAVE    :: a1                   ! Denominator coefficient 1
+        REAL(8), DIMENSION(99), SAVE    :: a0                   ! Denominator coefficient 0
+        REAL(8), DIMENSION(99), SAVE    :: b1                    ! Numerator coefficient 1
+        REAL(8), DIMENSION(99), SAVE    :: b0                    ! Numerator coefficient 0 
 
-        REAL(4), DIMENSION(99), SAVE    :: InputSignalLast      ! Input signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: OutputSignalLast ! Output signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: InputSignalLast      ! Input signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: OutputSignalLast ! Output signal the last time this filter was called. Supports 99 separate instances.
 
             ! Initialization
         IF ((iStatus == 0) .OR. reset) THEN   
@@ -73,25 +73,25 @@ CONTAINS
     ! Discrete time Low-Pass Filter of the form:
     !                               Continuous Time Form:   H(s) = CornerFreq^2/(s^2 + 2*CornerFreq*Damp*s + CornerFreq^2)
     !                               Discrete Time From:     H(z) = (b2*z^2 + b1*z + b0) / (a2*z^2 + a1*z + a0)
-        REAL(4), INTENT(IN)         :: InputSignal
-        REAL(4), INTENT(IN)         :: DT                       ! time step [s]
-        REAL(4), INTENT(IN)         :: CornerFreq               ! corner frequency [rad/s]
-        REAL(4), INTENT(IN)         :: Damp                     ! Dampening constant
+        REAL(8), INTENT(IN)         :: InputSignal
+        REAL(8), INTENT(IN)         :: DT                       ! time step [s]
+        REAL(8), INTENT(IN)         :: CornerFreq               ! corner frequency [rad/s]
+        REAL(8), INTENT(IN)         :: Damp                     ! Dampening constant
         INTEGER(4), INTENT(IN)      :: iStatus                  ! A status flag set by the simulation as follows: 0 if this is the first call, 1 for all subsequent time steps, -1 if this is the final call at the end of the simulation.
         INTEGER(4), INTENT(INOUT)   :: inst                     ! Instance number. Every instance of this function needs to have an unique instance number to ensure instances don't influence each other.
         LOGICAL(4), INTENT(IN)      :: reset                    ! Reset the filter to the input signal
 
         ! Local
-        REAL(4), DIMENSION(99), SAVE    :: a2                   ! Denominator coefficient 2
-        REAL(4), DIMENSION(99), SAVE    :: a1                   ! Denominator coefficient 1
-        REAL(4), DIMENSION(99), SAVE    :: a0                   ! Denominator coefficient 0
-        REAL(4), DIMENSION(99), SAVE    :: b2                   ! Numerator coefficient 2
-        REAL(4), DIMENSION(99), SAVE    :: b1                   ! Numerator coefficient 1
-        REAL(4), DIMENSION(99), SAVE    :: b0                   ! Numerator coefficient 0 
-        REAL(4), DIMENSION(99), SAVE    :: InputSignalLast1     ! Input signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: InputSignalLast2     ! Input signal the next to last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: OutputSignalLast1    ! Output signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: OutputSignalLast2    ! Output signal the next to last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: a2                   ! Denominator coefficient 2
+        REAL(8), DIMENSION(99), SAVE    :: a1                   ! Denominator coefficient 1
+        REAL(8), DIMENSION(99), SAVE    :: a0                   ! Denominator coefficient 0
+        REAL(8), DIMENSION(99), SAVE    :: b2                   ! Numerator coefficient 2
+        REAL(8), DIMENSION(99), SAVE    :: b1                   ! Numerator coefficient 1
+        REAL(8), DIMENSION(99), SAVE    :: b0                   ! Numerator coefficient 0 
+        REAL(8), DIMENSION(99), SAVE    :: InputSignalLast1     ! Input signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: InputSignalLast2     ! Input signal the next to last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: OutputSignalLast1    ! Output signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: OutputSignalLast2    ! Output signal the next to last time this filter was called. Supports 99 separate instances.
 
         ! Initialization
         IF ((iStatus == 0) .OR. reset )  THEN
@@ -129,16 +129,16 @@ CONTAINS
     REAL FUNCTION HPFilter( InputSignal, DT, CornerFreq, iStatus, reset, inst)
     ! Discrete time High-Pass Filter
 
-        REAL(4), INTENT(IN)     :: InputSignal
-        REAL(4), INTENT(IN)     :: DT                       ! time step [s]
-        REAL(4), INTENT(IN)     :: CornerFreq               ! corner frequency [rad/s]
+        REAL(8), INTENT(IN)     :: InputSignal
+        REAL(8), INTENT(IN)     :: DT                       ! time step [s]
+        REAL(8), INTENT(IN)     :: CornerFreq               ! corner frequency [rad/s]
         INTEGER, INTENT(IN)     :: iStatus                  ! A status flag set by the simulation as follows: 0 if this is the first call, 1 for all subsequent time steps, -1 if this is the final call at the end of the simulation.
         INTEGER, INTENT(INOUT)  :: inst                     ! Instance number. Every instance of this function needs to have an unique instance number to ensure instances don't influence each other.
         LOGICAL(4), INTENT(IN)  :: reset                    ! Reset the filter to the input signal
         ! Local
-        REAL(4)                         :: K                        ! Constant gain
-        REAL(4), DIMENSION(99), SAVE    :: InputSignalLast      ! Input signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: OutputSignalLast ! Output signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8)                         :: K                        ! Constant gain
+        REAL(8), DIMENSION(99), SAVE    :: InputSignalLast      ! Input signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: OutputSignalLast ! Output signal the last time this filter was called. Supports 99 separate instances.
 
         ! Initialization
         IF ((iStatus == 0) .OR. reset)  THEN
@@ -160,19 +160,19 @@ CONTAINS
     REAL FUNCTION NotchFilterSlopes(InputSignal, DT, CornerFreq, Damp, iStatus, reset, inst)
     ! Discrete time inverted Notch Filter with descending slopes, G = CornerFreq*s/(Damp*s^2+CornerFreq*s+Damp*CornerFreq^2)
 
-        REAL(4), INTENT(IN)     :: InputSignal
-        REAL(4), INTENT(IN)     :: DT                       ! time step [s]
-        REAL(4), INTENT(IN)     :: CornerFreq               ! corner frequency [rad/s]
-        REAL(4), INTENT(IN)     :: Damp                     ! Dampening constant
+        REAL(8), INTENT(IN)     :: InputSignal
+        REAL(8), INTENT(IN)     :: DT                       ! time step [s]
+        REAL(8), INTENT(IN)     :: CornerFreq               ! corner frequency [rad/s]
+        REAL(8), INTENT(IN)     :: Damp                     ! Dampening constant
         INTEGER, INTENT(IN)     :: iStatus                  ! A status flag set by the simulation as follows: 0 if this is the first call, 1 for all subsequent time steps, -1 if this is the final call at the end of the simulation.
         INTEGER, INTENT(INOUT)  :: inst                     ! Instance number. Every instance of this function needs to have an unique instance number to ensure instances don't influence each other.
         LOGICAL(4), INTENT(IN)  :: reset                    ! Reset the filter to the input signal
         ! Local
-        REAL(4), DIMENSION(99), SAVE :: b2, b0, a2, a1, a0    ! Input signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE :: InputSignalLast1    ! Input signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE :: InputSignalLast2    ! Input signal the next to last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE :: OutputSignalLast1   ! Output signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE :: OutputSignalLast2   ! Output signal the next to last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE :: b2, b0, a2, a1, a0    ! Input signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE :: InputSignalLast1    ! Input signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE :: InputSignalLast2    ! Input signal the next to last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE :: OutputSignalLast1   ! Output signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE :: OutputSignalLast2   ! Output signal the next to last time this filter was called. Supports 99 separate instances.
         
         ! Initialization
         IF ((iStatus == 0) .OR. reset) THEN
@@ -208,20 +208,20 @@ CONTAINS
     !                               Continuous Time Form: G(s) = (s^2 + 2*omega*betaNum*s + omega^2)/(s^2 + 2*omega*betaDen*s + omega^2)
     !                               Discrete Time Form:   H(z) = (b2*z^2 +b1*z^2 + b0*z)/((z^2 +a1*z^2 + a0*z))
 
-        REAL(4), INTENT(IN)     :: InputSignal
-        REAL(4), INTENT(IN)     :: DT                       ! time step [s]
-        REAL(4), INTENT(IN)     :: omega                    ! corner frequency [rad/s]
-        REAL(4), INTENT(IN)     :: betaNum                  ! Dampening constant in numerator of filter transfer function
-        REAL(4), INTENT(IN)     :: betaDen                  ! Dampening constant in denominator of filter transfer function
+        REAL(8), INTENT(IN)     :: InputSignal
+        REAL(8), INTENT(IN)     :: DT                       ! time step [s]
+        REAL(8), INTENT(IN)     :: omega                    ! corner frequency [rad/s]
+        REAL(8), INTENT(IN)     :: betaNum                  ! Dampening constant in numerator of filter transfer function
+        REAL(8), INTENT(IN)     :: betaDen                  ! Dampening constant in denominator of filter transfer function
         INTEGER, INTENT(IN)     :: iStatus                  ! A status flag set by the simulation as follows: 0 if this is the first call, 1 for all subsequent time steps, -1 if this is the final call at the end of the simulation.
         INTEGER, INTENT(INOUT)  :: inst                     ! Instance number. Every instance of this function needs to have an unique instance number to ensure instances don't influence each other.
         LOGICAL(4), INTENT(IN)  :: reset                    ! Reset the filter to the input signal
         ! Local
-        REAL(4), DIMENSION(99), SAVE    :: K, b2, b1, b0, a1, a0    ! Constant gain
-        REAL(4), DIMENSION(99), SAVE    :: InputSignalLast1         ! Input signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: InputSignalLast2         ! Input signal the next to last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: OutputSignalLast1        ! Output signal the last time this filter was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: OutputSignalLast2        ! Output signal the next to last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: K, b2, b1, b0, a1, a0    ! Constant gain
+        REAL(8), DIMENSION(99), SAVE    :: InputSignalLast1         ! Input signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: InputSignalLast2         ! Input signal the next to last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: OutputSignalLast1        ! Output signal the last time this filter was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: OutputSignalLast2        ! Output signal the next to last time this filter was called. Supports 99 separate instances.
 
         ! Initialization
         IF ((iStatus == 0) .OR. reset) THEN
@@ -276,12 +276,13 @@ CONTAINS
         IF (CntrPar%Fl_Mode == 1) THEN
             ! Force to start at 0
             IF (LocalVar%iStatus == 0) THEN
-                LocalVar%NacIMU_FA_AccF = SecLPFilter(0., LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+                LocalVar%NacIMU_FA_AccF = SecLPFilter(0.D0, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
             ELSE
                 LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
             ENDIF
-                LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, 0.0167, LocalVar%iStatus, .FALSE., objInst%instHPF) 
+            LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, 0.0167D0, LocalVar%iStatus, .FALSE., objInst%instHPF) 
             ! LocalVar%NacIMU_FA_AccF = NotchFilterSlopes(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instNotchSlopes) ! Fixed Damping
+            
             IF (CntrPar%F_NotchType >= 2) THEN
                 LocalVar%NACIMU_FA_AccF = NotchFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_NotchCornerFreq, CntrPar%F_NotchBetaNumDen(1), CntrPar%F_NotchBetaNumDen(2), LocalVar%iStatus, .FALSE., objInst%instNotch) ! Fixed Damping
             ENDIF
@@ -290,11 +291,10 @@ CONTAINS
         LocalVar%FA_AccHPF = HPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%FA_HPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instHPF)
         
         ! Wind Speed Estimator
-        ! LocalVar%We_Vw_F = SecLPFilter(LocalVar%We_Vw, LocalVar%DT, 0.62831, 0.7, LocalVar%iStatus, .FALSE., objInst%instSecLPF)
-        LocalVar%We_Vw_F = LPFilter(LocalVar%We_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq/2.0, LocalVar%iStatus, .FALSE., objInst%instLPF)
+        LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw,LocalVar%DT,0.21D0,0.7D0,LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
 
         ! Control commands (used by WSE, mostly)
-        LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7, LocalVar%iStatus, .FALSE., objInst%instSecLPF)
+        LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7D0, LocalVar%iStatus, .FALSE., objInst%instSecLPF)
         LocalVar%PC_PitComTF = LPFilter(LocalVar%PC_PitComT, LocalVar%dt, CntrPar%F_LPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF)
 
     END SUBROUTINE PreFilterMeasuredSignals

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -501,7 +501,7 @@ CONTAINS
         ! If we're debugging, open the debug file and write the header:
             ! Note that the headers will be Truncated to 10 characters!!
             IF (CntrPar%LoggingLevel > 0) THEN
-                OPEN(unit=UnDb, FILE=RootName(1:size_avcOUTNAME-5)//'RO.out')
+                OPEN(unit=UnDb, FILE=RootName(1:size_avcOUTNAME-5)//'RO.dbg')
                 WRITE (UnDb,'(99(a10,TR5:))') 'Time',   DebugOutStrings
                 WRITE (UnDb,'(99(a10,TR5:))') '(sec)',  DebugOutUnits
             END IF

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -473,7 +473,7 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 20
+        nDebugOuts = 18
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         ! Filters
@@ -495,10 +495,8 @@ CONTAINS
         DebugOutStr14  = 'WE_w';         DebugOutUni14  = '(rad/s)';   DebugOutData(14)  = DebugVar%WE_w
         DebugOutStr15  = 'WE_Vm';        DebugOutUni15  = '(m/s)';     DebugOutData(15)  = DebugVar%WE_Vm
         DebugOutStr16  = 'WE_Vt';        DebugOutUni16  = '(m/s)';     DebugOutData(16)  = DebugVar%WE_Vt
-        DebugOutStr17  = 'WE_Cp';        DebugOutUni17  = '(-)';       DebugOutData(17)  = DebugVar%WE_Cp
-        DebugOutStr18  = 'WE_lambda';    DebugOutUni18  = '(rad/s)';   DebugOutData(18)  = DebugVar%WE_lambda
-        DebugOutStr19  = 'WE_F12';       DebugOutUni19  = '(-)';       DebugOutData(19)  = DebugVar%WE_F12
-        DebugOutStr20  = 'WE_F13';       DebugOutUni20  = '(-)';       DebugOutData(20)  = DebugVar%WE_F13
+        DebugOutStr17  = 'WE_lambda';    DebugOutUni17  = '(rad/s)';   DebugOutData(17)  = DebugVar%WE_lambda
+        DebugOutStr18  = 'WE_Cp';        DebugOutUni18  = '(-)';       DebugOutData(18)  = DebugVar%WE_Cp
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
@@ -506,12 +504,12 @@ CONTAINS
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
                                                 DebugOutStr9, DebugOutStr10, DebugOutStr11, DebugOutStr12, &
                                                 DebugOutStr13, DebugOutStr14, DebugOutStr15, DebugOutStr16, &
-                                                DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20]
+                                                DebugOutStr17, DebugOutStr18]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
                                                 DebugOutUni9, DebugOutUni10, DebugOutUni11, DebugOutUni12, &
                                                 DebugOutUni13, DebugOutUni14, DebugOutUni15, DebugOutUni1, &
-                                                DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20]
+                                                DebugOutUni17, DebugOutUni18]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL
@@ -523,7 +521,7 @@ CONTAINS
                 WRITE (UnDb,'(99(a10,TR5:))') '(sec)',  DebugOutUnits
             END IF
             
-            IF (CntrPar%LoggingLevel > 1) THEN
+            IF (CntrPar%LoggingLevel > 1) THEN 
                 OPEN(unit=UnDb2, FILE='DEBUG2.dbg')
                 WRITE(UnDb2,'(/////)')
                 WRITE(UnDb2,'(A,85("'//Tab//'AvrSWAP(",I2,")"))')  'LocalVar%Time ', (i,i=1,85)

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -275,8 +275,8 @@ CONTAINS
         fQ(1,2) = zData(i,jj)
         fQ(2,2) = zData(ii,jj)
         ! Interpolate
-        fxy1 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,1)
-        fxy2 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,2) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,1)
+        fxy1 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(1,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(1,2)
+        fxy2 = (xData(jj) - xq)/(xData(jj) - xData(j))*fQ(2,1) + (xq - xData(j))/(xData(jj) - xData(j))*fQ(2,2)
         fxy = (yData(ii) - yq)/(yData(ii) - yData(i))*fxy1 + (yq - yData(i))/(yData(ii) - yData(i))*fxy2
 
         interp2d = fxy(1)
@@ -472,7 +472,7 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 8
+        nDebugOuts = 9
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         DebugOutStr1  = 'IMU_FA_AccF';     DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
@@ -483,13 +483,16 @@ CONTAINS
         DebugOutStr6  = 'WE_Cp';           DebugOutUni6  = '(-)';        DebugOutData(6)  = DebugVar%WE_Cp
         DebugOutStr7  = 'PC_MinPit';       DebugOutUni7  = '(rad)';      DebugOutData(7)  = LocalVar%PC_MinPit
         DebugOutStr8  = 'SS_dOmF';         DebugOutUni8  = '(rad/s)';    DebugOutData(8)  = LocalVar%SS_DelOmegaF
+        DebugOutStr9  = 'WE_Pitch';        DebugOutUni8  = '(rad)';      DebugOutData(9)  = DebugVar%WE_Pitch
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
         DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
-                                                DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8]
+                                                DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
+                                                DebugOutStr9]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
-                                                DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8]
+                                                DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
+                                                DebugOutUni9]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL
@@ -521,7 +524,7 @@ CONTAINS
 
         ! Want debug on first timestep
         IF (CntrPar%LoggingLevel > 0) THEN
-            WRITE (UnDb,FmtDat)     LocalVar%Time, LocalVar%NacIMU_FA_AccF, LocalVar%WE_Vw, LocalVar%NacIMU_FA_Acc, LocalVar%FA_Acc, LocalVar%Fl_PitCom, DebugVar%WE_Cp, LocalVar%PC_MinPit, LocalVar%SS_DelOmegaF
+            WRITE (UnDb,FmtDat)  LocalVar%Time, DebugOutData
         END IF
         
         IF (MODULO(LocalVar%Time, 10.0) == 0.0) THEN

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -496,7 +496,7 @@ CONTAINS
         ! If we're debugging, open the debug file and write the header:
             ! Note that the headers will be Truncated to 10 characters!!
             IF (CntrPar%LoggingLevel > 0) THEN
-                OPEN(unit=UnDb, FILE='DEBUG.dbg')
+                OPEN(unit=UnDb, FILE=RootName(1:size_avcOUTNAME-5)//'RO.out')
                 WRITE (UnDb,'(99(a10,TR5:))') 'Time',   DebugOutStrings
                 WRITE (UnDb,'(99(a10,TR5:))') '(sec)',  DebugOutUnits
             END IF

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -471,27 +471,29 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 9
+        nDebugOuts = 11
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
-        DebugOutStr1  = 'IMU_FA_AccF';     DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
+        DebugOutStr1  = 'FA_AccF';         DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
         DebugOutStr2  = 'WE_Vw';           DebugOutUni2  = '(rad)';      DebugOutData(2)  = LocalVar%WE_Vw
-        DebugOutStr3  = 'IMU_FA_Acc';      DebugOutUni3  = '(rad/s^2)';  DebugOutData(3)  = LocalVar%NacIMU_FA_Acc
+        DebugOutStr3  = 'FA_AccR';          DebugOutUni3  = '(rad/s^2)';  DebugOutData(3)  = LocalVar%NacIMU_FA_Acc
         DebugOutStr4  = 'FA_Acc';          DebugOutUni4  = '(m/s^2)';    DebugOutData(4)  = LocalVar%FA_Acc
         DebugOutStr5  = 'Fl_Pitcom';       DebugOutUni5  = '(rad)';      DebugOutData(5)  = LocalVar%Fl_Pitcom
         DebugOutStr6  = 'WE_Cp';           DebugOutUni6  = '(-)';        DebugOutData(6)  = DebugVar%WE_Cp
         DebugOutStr7  = 'PC_MinPit';       DebugOutUni7  = '(rad)';      DebugOutData(7)  = LocalVar%PC_MinPit
         DebugOutStr8  = 'SS_dOmF';         DebugOutUni8  = '(rad/s)';    DebugOutData(8)  = LocalVar%SS_DelOmegaF
-        DebugOutStr9  = 'WE_Pitch';        DebugOutUni8  = '(rad)';      DebugOutData(9)  = DebugVar%WE_Pitch
+        DebugOutStr9  = 'WE_b';            DebugOutUni9  = '(deg)';      DebugOutData(9)  = DebugVar%WE_b
+        DebugOutStr10  = 'WE_t';            DebugOutUni10  = '(Nm)';      DebugOutData(10)  = DebugVar%WE_t
+        DebugOutStr11  = 'WE_w';            DebugOutUni11  = '(rad/s)';      DebugOutData(11)  = DebugVar%WE_w
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
         DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
-                                                DebugOutStr9]
+                                                DebugOutStr9, DebugOutStr10, DebugOutStr11]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
-                                                DebugOutUni9]
+                                                DebugOutUni9, DebugOutUni10, DebugOutUni11]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -471,7 +471,7 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 11
+        nDebugOuts = 12
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         DebugOutStr1  = 'FA_AccF';         DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
@@ -485,15 +485,16 @@ CONTAINS
         DebugOutStr9  = 'WE_b';            DebugOutUni9  = '(deg)';      DebugOutData(9)  = DebugVar%WE_b
         DebugOutStr10  = 'WE_t';            DebugOutUni10  = '(Nm)';      DebugOutData(10)  = DebugVar%WE_t
         DebugOutStr11  = 'WE_w';            DebugOutUni11  = '(rad/s)';      DebugOutData(11)  = DebugVar%WE_w
+        DebugOutStr12  = 'WE_D';            DebugOutUni12  = '()';      DebugOutData(12)  = DebugVar%WE_D
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
         DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
-                                                DebugOutStr9, DebugOutStr10, DebugOutStr11]
+                                                DebugOutStr9, DebugOutStr10, DebugOutStr11, DebugOutStr12]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
-                                                DebugOutUni9, DebugOutUni10, DebugOutUni11]
+                                                DebugOutUni9, DebugOutUni10, DebugOutUni11, DebugOutUni12]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -226,12 +226,12 @@ CONTAINS
             interp2d = interp1d(yData,zData(:,j),yq)
             RETURN
         ELSE
-            DO j = 1,size(xData)            ! On axis, just need 1d interpolation
-                IF (xq == xData(j)) THEN
+            DO j = 1,size(xData)            
+                IF (xq == xData(j)) THEN ! On axis, just need 1d interpolation
                     jj = j
                     interp2d = interp1d(yData,zData(:,j),yq)
                     RETURN
-                ELSEIF (xq <= xData(j)) THEN
+                ELSEIF (xq < xData(j)) THEN
                     jj = j
                     EXIT
                 ELSE
@@ -256,9 +256,8 @@ CONTAINS
                 IF (yq == yData(i)) THEN    ! On axis, just need 1d interpolation
                     ii = i
                     interp2d = interp1d(xData,zData(i,:),xq)
-                    ! interp2d = interp1d(yData,zData(i,:),xq)
                     RETURN
-                ELSEIF (yq <= yData(i)) THEN
+                ELSEIF (yq < yData(i)) THEN
                     ii = i
                     EXIT
                 ELSE
@@ -432,10 +431,10 @@ CONTAINS
         
         ! Find Torque
         RotorArea = PI*CntrPar%WE_BladeRadius**2
-        Lambda = LocalVar%RotSpeed*CntrPar%WE_BladeRadius/LocalVar%WE_Vw
+        Lambda = LocalVar%RotSpeedF*CntrPar%WE_BladeRadius/LocalVar%WE_Vw
         ! Cp = CPfunction(CntrPar%WE_CP, Lambda)
-        Cp = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%BlPitch(1)*R2D, Lambda)
-        AeroDynTorque = 0.5*(CntrPar%WE_RhoAir*RotorArea)*(LocalVar%WE_Vw**3/LocalVar%RotSpeed)*Cp
+        Cp = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%PC_PitComTF*R2D, Lambda)
+        AeroDynTorque = 0.5*(CntrPar%WE_RhoAir*RotorArea)*(LocalVar%WE_Vw**3/LocalVar%RotSpeedF)*Cp
         AeroDynTorque = MAX(AeroDynTorque, 0.0)
         
     END FUNCTION AeroDynTorque
@@ -463,8 +462,8 @@ CONTAINS
         
         CHARACTER(10)                               :: DebugOutStr1,  DebugOutStr2, DebugOutStr3, DebugOutStr4, DebugOutStr5, &
                                                          DebugOutStr6, DebugOutStr7, DebugOutStr8, DebugOutStr9, DebugOutStr10, &
-                                                         DebugOutStr11, DebugOutStr12, DebugOutStr13, DebugOutStr14, DebugOutStr15, & 
-                                                         DebugOutUni1,  DebugOutUni2, DebugOutUni3, DebugOutUni4, DebugOutUni5, &
+                                                         DebugOutStr11, DebugOutStr12, DebugOutStr13, DebugOutStr14, DebugOutStr15                                                         
+        CHARACTER(10)                               :: DebugOutUni1,  DebugOutUni2, DebugOutUni3, DebugOutUni4, DebugOutUni5, &
                                                          DebugOutUni6, DebugOutUni7, DebugOutUni8, DebugOutUni9, DebugOutUni10, &
                                                          DebugOutUni11, DebugOutUni12, DebugOutUni13, DebugOutUni14, DebugOutUni15 
         CHARACTER(10), ALLOCATABLE                  :: DebugOutStrings(:), DebugOutUnits(:)
@@ -517,19 +516,16 @@ CONTAINS
                 100 FORMAT('Generator speed: ', f6.1, ' RPM, Pitch angle: ', f5.1, ' deg, Power: ', f7.1, ' kW, Est. wind Speed: ', f5.1, ' m/s')
             END IF
             
-            IF (CntrPar%LoggingLevel > 1) THEN
-                WRITE (UnDb2,FmtDat)    LocalVar%Time, avrSWAP(1:85)
-            END IF
-        END IF
+        ENDIF
 
-        ! Want debug on first timestep
+        ! Write debug files
         IF (CntrPar%LoggingLevel > 0) THEN
             WRITE (UnDb,FmtDat)  LocalVar%Time, DebugOutData
         END IF
-        
-        IF (MODULO(LocalVar%Time, 10.0) == 0.0) THEN
-            !LocalVar%TestType = LocalVar%TestType + 10
-            !PRINT *, LocalVar%TestType
+
+        IF (CntrPar%LoggingLevel > 1) THEN
+            WRITE (UnDb2,FmtDat)    LocalVar%Time, avrSWAP(1:85)
         END IF
+
     END SUBROUTINE Debug
 END MODULE Functions

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -440,33 +440,65 @@ CONTAINS
         
     END FUNCTION AeroDynTorque
 !-------------------------------------------------------------------------------------------------------------------------------
-    SUBROUTINE Debug(LocalVar, CntrPar, avrSWAP, RootName, size_avcOUTNAME)
+    SUBROUTINE Debug(LocalVar, CntrPar, DebugVar, avrSWAP, RootName, size_avcOUTNAME)
     ! Debug routine, defines what gets printed to DEBUG.dbg if LoggingLevel = 1
     
         USE, INTRINSIC  :: ISO_C_Binding
-        USE ROSCO_Types, ONLY : LocalVariables, ControlParameters
+        USE ROSCO_Types, ONLY : LocalVariables, ControlParameters, DebugVariables
         
         IMPLICIT NONE
     
         TYPE(ControlParameters), INTENT(IN)     :: CntrPar
         TYPE(LocalVariables), INTENT(IN)        :: LocalVar
+        TYPE(DebugVariables), INTENT(IN)        :: DebugVar
     
         INTEGER(4), INTENT(IN)                      :: size_avcOUTNAME
-        INTEGER(4)                                  :: I                ! Generic index.
+        INTEGER(4)                                  :: I , nDebugOuts               ! Generic index.
         CHARACTER(1), PARAMETER                     :: Tab = CHAR(9)                        ! The tab character.
-        CHARACTER(25), PARAMETER                    :: FmtDat = "(F8.3,99('"//Tab//"',ES10.3E2,:))  "   ! The format of the debugging data
+        CHARACTER(29), PARAMETER                    :: FmtDat = "(F10.3,TR5,99(ES10.3E2,TR5:))"   ! The format of the debugging data
         INTEGER(4), PARAMETER                       :: UnDb = 85        ! I/O unit for the debugging information
         INTEGER(4), PARAMETER                       :: UnDb2 = 86       ! I/O unit for the debugging information, avrSWAP
         REAL(C_FLOAT), INTENT(INOUT)                :: avrSWAP(*)   ! The swap array, used to pass data to, and receive data from, the DLL controller.
         CHARACTER(size_avcOUTNAME-1), INTENT(IN)    :: RootName     ! a Fortran version of the input C string (not considered an array here)    [subtract 1 for the C null-character]
         
+        CHARACTER(10)                               :: DebugOutStr1,  DebugOutStr2, DebugOutStr3, DebugOutStr4, DebugOutStr5, &
+                                                         DebugOutStr6, DebugOutStr7, DebugOutStr8, DebugOutStr9, DebugOutStr10, &
+                                                         DebugOutStr11, DebugOutStr12, DebugOutStr13, DebugOutStr14, DebugOutStr15, & 
+                                                         DebugOutUni1,  DebugOutUni2, DebugOutUni3, DebugOutUni4, DebugOutUni5, &
+                                                         DebugOutUni6, DebugOutUni7, DebugOutUni8, DebugOutUni9, DebugOutUni10, &
+                                                         DebugOutUni11, DebugOutUni12, DebugOutUni13, DebugOutUni14, DebugOutUni15 
+        CHARACTER(10), ALLOCATABLE                  :: DebugOutStrings(:), DebugOutUnits(:)
+        REAL(4), ALLOCATABLE                        :: DebugOutData(:)
+
+        ! Set up Debug Strings and Data
+        ! Note that Debug strings have 10 character limit
+        nDebugOuts = 8
+        ALLOCATE(DebugOutData(nDebugOuts))
+        !                 Header                            Unit                                Variable
+        DebugOutStr1  = 'IMU_FA_AccF';     DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
+        DebugOutStr2  = 'WE_Vw';           DebugOutUni2  = '(rad)';      DebugOutData(2)  = LocalVar%WE_Vw
+        DebugOutStr3  = 'IMU_FA_Acc';      DebugOutUni3  = '(rad/s^2)';  DebugOutData(3)  = LocalVar%NacIMU_FA_Acc
+        DebugOutStr4  = 'FA_Acc';          DebugOutUni4  = '(m/s^2)';    DebugOutData(4)  = LocalVar%FA_Acc
+        DebugOutStr5  = 'Fl_Pitcom';       DebugOutUni5  = '(rad)';      DebugOutData(5)  = LocalVar%Fl_Pitcom
+        DebugOutStr6  = 'WE_Cp';           DebugOutUni6  = '(-)';        DebugOutData(6)  = DebugVar%WE_Cp
+        DebugOutStr7  = 'PC_MinPit';       DebugOutUni7  = '(rad)';      DebugOutData(7)  = LocalVar%PC_MinPit
+        DebugOutStr8  = 'SS_dOmF';         DebugOutUni8  = '(rad/s)';    DebugOutData(8)  = LocalVar%SS_DelOmegaF
+
+        Allocate(DebugOutStrings(nDebugOuts))
+        Allocate(DebugOutUnits(nDebugOuts))
+        DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
+                                                DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8]
+        DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
+                                                DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8]
+        
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL
         ! If we're debugging, open the debug file and write the header:
+            ! Note that the headers will be Truncated to 10 characters!!
             IF (CntrPar%LoggingLevel > 0) THEN
                 OPEN(unit=UnDb, FILE='DEBUG.dbg')
-                WRITE (UnDb,'(A)')  '   Time '  //Tab//' NacIMU_FA_AccF    ' //Tab//' WE_Vw    '  //Tab//' NacIMU_FA_Acc    ' //Tab//' FA_Acc    '   //Tab//' Fl_Pitcom    ' //Tab//' WE_Cp    ' //Tab//' PC_MinPit    ' //Tab// ' SS_DelOmegaF      '
-                WRITE (UnDb,'(A)')  '   (sec) '  //Tab//'(m/s) ' //Tab//'(rad) ' //Tab//'(rad/s^2) ' //Tab//'(m/s^2) '//Tab//'(rad) ' //Tab//'(-) ' //Tab//'(rad)'  //Tab // '(rad/s)'
+                WRITE (UnDb,'(99(a10,TR5:))') 'Time',   DebugOutStrings
+                WRITE (UnDb,'(99(a10,TR5:))') '(sec)',  DebugOutUnits
             END IF
             
             IF (CntrPar%LoggingLevel > 1) THEN
@@ -482,14 +514,14 @@ CONTAINS
                 100 FORMAT('Generator speed: ', f6.1, ' RPM, Pitch angle: ', f5.1, ' deg, Power: ', f7.1, ' kW, Est. wind Speed: ', f5.1, ' m/s')
             END IF
             
-            ! Output debugging information if requested:
-            IF (CntrPar%LoggingLevel > 0) THEN
-                WRITE (UnDb,FmtDat)     LocalVar%Time, LocalVar%NacIMU_FA_AccF, LocalVar%WE_Vw, LocalVar%NacIMU_FA_Acc, LocalVar%FA_Acc, LocalVar%Fl_PitCom, LocalVar%WE_Cp, LocalVar%PC_MinPit, LocalVar%SS_DelOmegaF
-            END IF
-            
             IF (CntrPar%LoggingLevel > 1) THEN
-                WRITE (UnDb2,FmtDat)    LocalVar%Time, avrSWAP(1:85)
+                WRITE (UnDb2,FmtDat)    LocalVar%Time, DebugOutData
             END IF
+        END IF
+
+        ! Want debug on first timestep
+        IF (CntrPar%LoggingLevel > 0) THEN
+            WRITE (UnDb,FmtDat)     LocalVar%Time, LocalVar%NacIMU_FA_AccF, LocalVar%WE_Vw, LocalVar%NacIMU_FA_Acc, LocalVar%FA_Acc, LocalVar%Fl_PitCom, DebugVar%WE_Cp, LocalVar%PC_MinPit, LocalVar%SS_DelOmegaF
         END IF
         
         IF (MODULO(LocalVar%Time, 10.0) == 0.0) THEN

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -515,7 +515,7 @@ CONTAINS
             END IF
             
             IF (CntrPar%LoggingLevel > 1) THEN
-                WRITE (UnDb2,FmtDat)    LocalVar%Time, DebugOutData
+                WRITE (UnDb2,FmtDat)    LocalVar%Time, avrSWAP(1:85)
             END IF
         END IF
 

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -40,9 +40,9 @@ CONTAINS
 
         IMPLICIT NONE
 
-        REAL(4), INTENT(IN)     :: inputValue
-        REAL(4), INTENT(IN)     :: minValue
-        REAL(4), INTENT(IN)     :: maxValue
+        REAL(8), INTENT(IN)     :: inputValue
+        REAL(8), INTENT(IN)     :: minValue
+        REAL(8), INTENT(IN)     :: maxValue
 
         saturate = MIN(MAX(inputValue,minValue), maxValue)
 
@@ -52,13 +52,13 @@ CONTAINS
     ! Saturates inputValue. Makes sure it is not smaller than minValue and not larger than maxValue
         IMPLICIT NONE
 
-        REAL(4), INTENT(IN)     :: inputSignal
-        REAL(4), INTENT(IN)     :: inputSignalPrev
-        REAL(4), INTENT(IN)     :: minRate
-        REAL(4), INTENT(IN)     :: maxRate
-        REAL(4), INTENT(IN)     :: DT
+        REAL(8), INTENT(IN)     :: inputSignal
+        REAL(8), INTENT(IN)     :: inputSignalPrev
+        REAL(8), INTENT(IN)     :: minRate
+        REAL(8), INTENT(IN)     :: maxRate
+        REAL(8), INTENT(IN)     :: DT
         ! Local variables
-        REAL(4)                 :: rate
+        REAL(8)                 :: rate
 
         rate = (inputSignal - inputSignalPrev)/DT                       ! Signal rate (unsaturated)
         rate = saturate(rate, minRate, maxRate)                 ! Saturate the signal rate
@@ -71,20 +71,20 @@ CONTAINS
 
         IMPLICIT NONE
         ! Allocate Inputs
-        REAL(4), INTENT(IN)         :: error
-        REAL(4), INTENT(IN)         :: kp
-        REAL(4), INTENT(IN)         :: ki
-        REAL(4), INTENT(IN)         :: minValue
-        REAL(4), INTENT(IN)         :: maxValue
-        REAL(4), INTENT(IN)         :: DT
+        REAL(8), INTENT(IN)         :: error
+        REAL(8), INTENT(IN)         :: kp
+        REAL(8), INTENT(IN)         :: ki
+        REAL(8), INTENT(IN)         :: minValue
+        REAL(8), INTENT(IN)         :: maxValue
+        REAL(8), INTENT(IN)         :: DT
         INTEGER(4), INTENT(INOUT)   :: inst
-        REAL(4), INTENT(IN)         :: I0
+        REAL(8), INTENT(IN)         :: I0
         LOGICAL, INTENT(IN)         :: reset     
         ! Allocate local variables
         INTEGER(4)                      :: i                                            ! Counter for making arrays
-        REAL(4)                         :: PTerm                                        ! Proportional term
-        REAL(4), DIMENSION(99), SAVE    :: ITerm = (/ (real(9999.9), i = 1,99) /)       ! Integral term, current.
-        REAL(4), DIMENSION(99), SAVE    :: ITermLast = (/ (real(9999.9), i = 1,99) /)   ! Integral term, the last time this controller was called. Supports 99 separate instances.
+        REAL(8)                         :: PTerm                                        ! Proportional term
+        REAL(8), DIMENSION(99), SAVE    :: ITerm = (/ (real(9999.9), i = 1,99) /)       ! Integral term, current.
+        REAL(8), DIMENSION(99), SAVE    :: ITermLast = (/ (real(9999.9), i = 1,99) /)   ! Integral term, the last time this controller was called. Supports 99 separate instances.
         INTEGER(4), DIMENSION(99), SAVE :: FirstCall = (/ (1, i=1,99) /)                ! First call of this function?
         
         ! Initialize persistent variables/arrays, and set inital condition for integrator term
@@ -98,7 +98,7 @@ CONTAINS
             PTerm = kp*error
             ITerm(inst) = ITerm(inst) + DT*ki*error
             ITerm(inst) = saturate(ITerm(inst), minValue, maxValue)
-            PIController = PTerm + ITerm(inst)
+            PIController = saturate(PTerm + ITerm(inst), minValue, maxValue)
         
             ITermLast(inst) = ITerm(inst)
         END IF
@@ -106,30 +106,30 @@ CONTAINS
         
     END FUNCTION PIController
 !-------------------------------------------------------------------------------------------------------------------------------
-    REAL FUNCTION PIIController(error, error2, kp, ki, ki2, minValue, maxValue, DT, I0, reset, inst)
+    REAL(8) FUNCTION PIIController(error, error2, kp, ki, ki2, minValue, maxValue, DT, I0, reset, inst)
     ! PI controller, with output saturation. 
     ! Added error2 term for additional integral control input
 
         IMPLICIT NONE
         ! Allocate Inputs
-        REAL(4), INTENT(IN)         :: error
-        REAL(4), INTENT(IN)         :: error2
-        REAL(4), INTENT(IN)         :: kp
-        REAL(4), INTENT(IN)         :: ki2
-        REAL(4), INTENT(IN)         :: ki
-        REAL(4), INTENT(IN)         :: minValue
-        REAL(4), INTENT(IN)         :: maxValue
-        REAL(4), INTENT(IN)         :: DT
+        REAL(8), INTENT(IN)         :: error
+        REAL(8), INTENT(IN)         :: error2
+        REAL(8), INTENT(IN)         :: kp
+        REAL(8), INTENT(IN)         :: ki2
+        REAL(8), INTENT(IN)         :: ki
+        REAL(8), INTENT(IN)         :: minValue
+        REAL(8), INTENT(IN)         :: maxValue
+        REAL(8), INTENT(IN)         :: DT
         INTEGER(4), INTENT(INOUT)   :: inst
-        REAL(4), INTENT(IN)         :: I0
+        REAL(8), INTENT(IN)         :: I0
         LOGICAL, INTENT(IN)         :: reset     
         ! Allocate local variables
         INTEGER(4)                      :: i                                            ! Counter for making arrays
-        REAL(4)                         :: PTerm                                        ! Proportional term
-        REAL(4), DIMENSION(99), SAVE    :: ITerm = (/ (real(9999.9), i = 1,99) /)       ! Integral term, current.
-        REAL(4), DIMENSION(99), SAVE    :: ITermLast = (/ (real(9999.9), i = 1,99) /)   ! Integral term, the last time this controller was called. Supports 99 separate instances.
-        REAL(4), DIMENSION(99), SAVE    :: ITerm2 = (/ (real(9999.9), i = 1,99) /)       ! Second Integral term, current.
-        REAL(4), DIMENSION(99), SAVE    :: ITermLast2 = (/ (real(9999.9), i = 1,99) /)   ! Second Integral term, the last time this controller was called. Supports 99 separate instances.
+        REAL(8)                         :: PTerm                                        ! Proportional term
+        REAL(8), DIMENSION(99), SAVE    :: ITerm = (/ (real(9999.9), i = 1,99) /)       ! Integral term, current.
+        REAL(8), DIMENSION(99), SAVE    :: ITermLast = (/ (real(9999.9), i = 1,99) /)   ! Integral term, the last time this controller was called. Supports 99 separate instances.
+        REAL(8), DIMENSION(99), SAVE    :: ITerm2 = (/ (real(9999.9), i = 1,99) /)       ! Second Integral term, current.
+        REAL(8), DIMENSION(99), SAVE    :: ITermLast2 = (/ (real(9999.9), i = 1,99) /)   ! Second Integral term, the last time this controller was called. Supports 99 separate instances.
         INTEGER(4), DIMENSION(99), SAVE :: FirstCall = (/ (1, i=1,99) /)                ! First call of this function?
         
         ! Initialize persistent variables/arrays, and set inital condition for integrator term
@@ -161,9 +161,9 @@ CONTAINS
 
         IMPLICIT NONE
         ! Inputs
-        REAL(4), DIMENSION(:), INTENT(IN)       :: xData        ! Provided x data (vector), to be interpolated
-        REAL(4), DIMENSION(:), INTENT(IN)       :: yData        ! Provided y data (vector), to be interpolated
-        REAL(4), INTENT(IN)                     :: xq           ! x-value for which the y value has to be interpolated
+        REAL(8), DIMENSION(:), INTENT(IN)       :: xData        ! Provided x data (vector), to be interpolated
+        REAL(8), DIMENSION(:), INTENT(IN)       :: yData        ! Provided y data (vector), to be interpolated
+        REAL(8), INTENT(IN)                     :: xq           ! x-value for which the y value has to be interpolated
         INTEGER(4)                              :: I            ! Iteration index
         
         ! Interpolate
@@ -198,20 +198,20 @@ CONTAINS
 
         IMPLICIT NONE
         ! Inputs
-        REAL(4), DIMENSION(:),   INTENT(IN)     :: xData        ! Provided x data (vector), to find query point (should be monotonically increasing)
-        REAL(4), DIMENSION(:),   INTENT(IN)     :: yData        ! Provided y data (vector), to find query point (should be monotonically increasing)
-        REAL(4), DIMENSION(:,:), INTENT(IN)     :: zData        ! Provided z data (vector), to be interpolated
-        REAL(4),                 INTENT(IN)     :: xq           ! x-value for which the z value has to be interpolated
-        REAL(4),                 INTENT(IN)     :: yq           ! y-value for which the z value has to be interpolated
+        REAL(8), DIMENSION(:),   INTENT(IN)     :: xData        ! Provided x data (vector), to find query point (should be monotonically increasing)
+        REAL(8), DIMENSION(:),   INTENT(IN)     :: yData        ! Provided y data (vector), to find query point (should be monotonically increasing)
+        REAL(8), DIMENSION(:,:), INTENT(IN)     :: zData        ! Provided z data (vector), to be interpolated
+        REAL(8),                 INTENT(IN)     :: xq           ! x-value for which the z value has to be interpolated
+        REAL(8),                 INTENT(IN)     :: yq           ! y-value for which the z value has to be interpolated
         ! Allocate variables
         INTEGER(4)                              :: i            ! Iteration index & query index, x-direction
         INTEGER(4)                              :: ii           ! Iteration index & second que .  ry index, x-direction
         INTEGER(4)                              :: j            ! Iteration index & query index, y-direction
         INTEGER(4)                              :: jj           ! Iteration index & second query index, y-direction
-        REAL(4), DIMENSION(2,2)                 :: fQ           ! zData value at query points for bilinear interpolation            
-        REAL(4), DIMENSION(1)                   :: fxy           ! Interpolated z-data point to be returned
-        REAL(4)                                 :: fxy1          ! zData value at query point for bilinear interpolation            
-        REAL(4)                                 :: fxy2          ! zData value at query point for bilinear interpolation            
+        REAL(8), DIMENSION(2,2)                 :: fQ           ! zData value at query points for bilinear interpolation            
+        REAL(8), DIMENSION(1)                   :: fxy           ! Interpolated z-data point to be returned
+        REAL(8)                                 :: fxy1          ! zData value at query point for bilinear interpolation            
+        REAL(8)                                 :: fxy2          ! zData value at query point for bilinear interpolation            
         
         ! ---- Find corner indices surrounding desired interpolation point -----
             ! x-direction
@@ -285,9 +285,9 @@ CONTAINS
     FUNCTION matinv3(A) RESULT(B)
     ! Performs a direct calculation of the inverse of a 3×3 matrix.
     ! Source: http://fortranwiki.org/fortran/show/Matrix+inversion
-        REAL(4), INTENT(IN) :: A(3,3)   !! Matrix
-        REAL(4)             :: B(3,3)   !! Inverse matrix
-        REAL(4)             :: detinv
+        REAL(8), INTENT(IN) :: A(3,3)   !! Matrix
+        REAL(8)             :: B(3,3)   !! Inverse matrix
+        REAL(8)             :: detinv
 
         ! Calculate the inverse determinant of the matrix
         detinv = 1/(A(1,1)*A(2,2)*A(3,3) - A(1,1)*A(2,3)*A(3,2)&
@@ -310,7 +310,7 @@ CONTAINS
     ! Produces an identity matrix of size n x n
 
         INTEGER, INTENT(IN)         :: n
-        REAL(4), DIMENSION(n, n)    :: A
+        REAL(8), DIMENSION(n, n)    :: A
         INTEGER                     :: i
         INTEGER                     :: j
 
@@ -332,16 +332,16 @@ CONTAINS
     
         IMPLICIT NONE
         ! Inputs
-        REAL(4), INTENT(IN)     :: error
-        REAL(4), INTENT(IN)     :: kd
-        REAL(4), INTENT(IN)     :: tf
-        REAL(4), INTENT(IN)     :: DT
+        REAL(8), INTENT(IN)     :: error
+        REAL(8), INTENT(IN)     :: kd
+        REAL(8), INTENT(IN)     :: tf
+        REAL(8), INTENT(IN)     :: DT
         INTEGER(4), INTENT(IN)  :: inst
         ! Local
-        REAL(4)                         :: B                                    ! 
+        REAL(8)                         :: B                                    ! 
         INTEGER(4)                      :: i                                    ! Counter for making arrays
-        REAL(4), DIMENSION(99), SAVE    :: errorLast = (/ (0, i=1,99) /)        ! 
-        REAL(4), DIMENSION(99), SAVE    :: DFControllerLast = (/ (0, i=1,99) /) ! 
+        REAL(8), DIMENSION(99), SAVE    :: errorLast = (/ (0, i=1,99) /)        ! 
+        REAL(8), DIMENSION(99), SAVE    :: DFControllerLast = (/ (0, i=1,99) /) ! 
         INTEGER(4), DIMENSION(99), SAVE :: FirstCall = (/ (1, i=1,99) /)        ! First call of this function?
         
         ! Initialize persistent variables/arrays, and set inital condition for integrator term
@@ -362,14 +362,14 @@ CONTAINS
 
         IMPLICIT NONE
         ! Inputs
-        REAL(4), INTENT(IN)     :: rootMOOP(3)                      ! Root out of plane bending moments of each blade
-        REAL(4), INTENT(IN)     :: aziAngle                         ! Rotor azimuth angle
+        REAL(8), INTENT(IN)     :: rootMOOP(3)                      ! Root out of plane bending moments of each blade
+        REAL(8), INTENT(IN)     :: aziAngle                         ! Rotor azimuth angle
         INTEGER(4), INTENT(IN)  :: nHarmonic                        ! The harmonic number, nP
         ! Outputs
-        REAL(4), INTENT(OUT)    :: axTOut, axYOut               ! Direct axis and quadrature axis outputted by this transform
+        REAL(8), INTENT(OUT)    :: axTOut, axYOut               ! Direct axis and quadrature axis outputted by this transform
         ! Local
-        REAL(4), PARAMETER      :: phi2 = 2.0/3.0*PI                ! Phase difference from first to second blade
-        REAL(4), PARAMETER      :: phi3 = 4.0/3.0*PI                ! Phase difference from first to third blade
+        REAL(8), PARAMETER      :: phi2 = 2.0/3.0*PI                ! Phase difference from first to second blade
+        REAL(8), PARAMETER      :: phi3 = 4.0/3.0*PI                ! Phase difference from first to third blade
 
         ! Body
         axTOut  = 2.0/3.0 * (cos(nHarmonic*(aziAngle))*rootMOOP(1) + cos(nHarmonic*(aziAngle+phi2))*rootMOOP(2) + cos(nHarmonic*(aziAngle+phi3))*rootMOOP(3))
@@ -382,15 +382,15 @@ CONTAINS
     ! back to root out of plane bending moments of each turbine blade
         IMPLICIT NONE
         ! Inputs
-        REAL(4), INTENT(IN)     :: axTIn, axYIn         ! Direct axis and quadrature axis
-        REAL(4), INTENT(IN)     :: aziAngle                     ! Rotor azimuth angle
-        REAL(4), INTENT(IN)     :: aziOffset                    ! Phase shift added to the azimuth angle
+        REAL(8), INTENT(IN)     :: axTIn, axYIn         ! Direct axis and quadrature axis
+        REAL(8), INTENT(IN)     :: aziAngle                     ! Rotor azimuth angle
+        REAL(8), INTENT(IN)     :: aziOffset                    ! Phase shift added to the azimuth angle
         INTEGER(4), INTENT(IN)  :: nHarmonic                    ! The harmonic number, nP
         ! Outputs
-        REAL(4), INTENT(OUT)    :: PitComIPC(3)                 ! Root out of plane bending moments of each blade
+        REAL(8), INTENT(OUT)    :: PitComIPC(3)                 ! Root out of plane bending moments of each blade
         ! Local
-        REAL(4), PARAMETER      :: phi2 = 2.0/3.0*PI                ! Phase difference from first to second blade
-        REAL(4), PARAMETER      :: phi3 = 4.0/3.0*PI                ! Phase difference from first to third blade
+        REAL(8), PARAMETER      :: phi2 = 2.0/3.0*PI                ! Phase difference from first to second blade
+        REAL(8), PARAMETER      :: phi3 = 4.0/3.0*PI                ! Phase difference from first to third blade
 
         ! Body
         PitComIPC(1) = cos(nHarmonic*(aziAngle+aziOffset))*axTIn + sin(nHarmonic*(aziAngle+aziOffset))*axYIn
@@ -404,8 +404,8 @@ CONTAINS
         IMPLICIT NONE
         
         ! Inputs
-        REAL(4), INTENT(IN) :: CP(4)    ! Parameters defining the parameterizable Cp(lambda) function
-        REAL(4), INTENT(IN) :: lambda    ! Estimated or measured tip-speed ratio input
+        REAL(8), INTENT(IN) :: CP(4)    ! Parameters defining the parameterizable Cp(lambda) function
+        REAL(8), INTENT(IN) :: lambda    ! Estimated or measured tip-speed ratio input
         
         ! Lookup
         CPfunction = exp(-CP(1)/lambda)*(CP(2)/lambda-CP(3))+CP(4)*lambda
@@ -425,9 +425,9 @@ CONTAINS
         TYPE(PerformanceData), INTENT(IN) :: PerfData
             
         ! Local
-        REAL(4) :: RotorArea
-        REAL(4) :: Cp
-        REAL(4) :: Lambda
+        REAL(8) :: RotorArea
+        REAL(8) :: Cp
+        REAL(8) :: Lambda
         
         ! Find Torque
         RotorArea = PI*CntrPar%WE_BladeRadius**2
@@ -462,39 +462,56 @@ CONTAINS
         
         CHARACTER(10)                               :: DebugOutStr1,  DebugOutStr2, DebugOutStr3, DebugOutStr4, DebugOutStr5, &
                                                          DebugOutStr6, DebugOutStr7, DebugOutStr8, DebugOutStr9, DebugOutStr10, &
-                                                         DebugOutStr11, DebugOutStr12, DebugOutStr13, DebugOutStr14, DebugOutStr15                                                         
+                                                         DebugOutStr11, DebugOutStr12, DebugOutStr13, DebugOutStr14, DebugOutStr15, & 
+                                                         DebugOutStr16, DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20                                                           
         CHARACTER(10)                               :: DebugOutUni1,  DebugOutUni2, DebugOutUni3, DebugOutUni4, DebugOutUni5, &
                                                          DebugOutUni6, DebugOutUni7, DebugOutUni8, DebugOutUni9, DebugOutUni10, &
-                                                         DebugOutUni11, DebugOutUni12, DebugOutUni13, DebugOutUni14, DebugOutUni15 
+                                                         DebugOutUni11, DebugOutUni12, DebugOutUni13, DebugOutUni14, DebugOutUni15, & 
+                                                         DebugOutUni16, DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20 
         CHARACTER(10), ALLOCATABLE                  :: DebugOutStrings(:), DebugOutUnits(:)
-        REAL(4), ALLOCATABLE                        :: DebugOutData(:)
+        REAL(8), ALLOCATABLE                        :: DebugOutData(:)
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 12
+        nDebugOuts = 20
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
-        DebugOutStr1  = 'FA_AccF';         DebugOutUni1  = '(m/s)';      DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
-        DebugOutStr2  = 'WE_Vw';           DebugOutUni2  = '(rad)';      DebugOutData(2)  = LocalVar%WE_Vw
-        DebugOutStr3  = 'FA_AccR';          DebugOutUni3  = '(rad/s^2)';  DebugOutData(3)  = LocalVar%NacIMU_FA_Acc
-        DebugOutStr4  = 'FA_Acc';          DebugOutUni4  = '(m/s^2)';    DebugOutData(4)  = LocalVar%FA_Acc
-        DebugOutStr5  = 'Fl_Pitcom';       DebugOutUni5  = '(rad)';      DebugOutData(5)  = LocalVar%Fl_Pitcom
-        DebugOutStr6  = 'WE_Cp';           DebugOutUni6  = '(-)';        DebugOutData(6)  = DebugVar%WE_Cp
-        DebugOutStr7  = 'PC_MinPit';       DebugOutUni7  = '(rad)';      DebugOutData(7)  = LocalVar%PC_MinPit
-        DebugOutStr8  = 'SS_dOmF';         DebugOutUni8  = '(rad/s)';    DebugOutData(8)  = LocalVar%SS_DelOmegaF
-        DebugOutStr9  = 'WE_b';            DebugOutUni9  = '(deg)';      DebugOutData(9)  = DebugVar%WE_b
-        DebugOutStr10  = 'WE_t';            DebugOutUni10  = '(Nm)';      DebugOutData(10)  = DebugVar%WE_t
-        DebugOutStr11  = 'WE_w';            DebugOutUni11  = '(rad/s)';      DebugOutData(11)  = DebugVar%WE_w
-        DebugOutStr12  = 'WE_D';            DebugOutUni12  = '()';      DebugOutData(12)  = DebugVar%WE_D
+        ! Filters
+        DebugOutStr1   = 'FA_AccF';     DebugOutUni1   = '(m/s)';      DebugOutData(1)   = LocalVar%NacIMU_FA_AccF
+        DebugOutStr2   = 'FA_AccR';     DebugOutUni2   = '(rad/s^2)';  DebugOutData(2)   = LocalVar%NacIMU_FA_Acc
+        DebugOutStr3  = 'RotSpeed';     DebugOutUni3  = '(rad/s)';     DebugOutData(3)  = LocalVar%RotSpeed
+        DebugOutStr4  = 'RotSpeedF';    DebugOutUni4  = '(rad/s)';     DebugOutData(4)  = LocalVar%RotSpeedF
+        DebugOutStr5  = 'GenSpeed';     DebugOutUni5  = '(rad/s)';     DebugOutData(5)  = LocalVar%GenSpeed
+        DebugOutStr6  = 'GenSpeedF';    DebugOutUni6  = '(rad/s)';     DebugOutData(6)  = LocalVar%GenSpeedF
+        ! Floating
+        DebugOutStr7  = 'FA_Acc';        DebugOutUni7  = '(m/s^2)';    DebugOutData(7)  = LocalVar%FA_Acc
+        DebugOutStr8  = 'Fl_Pitcom';     DebugOutUni8  = '(rad)';      DebugOutData(8)  = LocalVar%Fl_Pitcom
+        DebugOutStr9  = 'PC_MinPit';     DebugOutUni9  = '(rad)';      DebugOutData(9)  = LocalVar%PC_MinPit
+        DebugOutStr10  = 'SS_dOmF';      DebugOutUni10  = '(rad/s)';   DebugOutData(10)  = LocalVar%SS_DelOmegaF
+        ! WSE
+        DebugOutStr11  = 'WE_Vw';        DebugOutUni11  = '(rad)';     DebugOutData(11)  = LocalVar%WE_Vw
+        DebugOutStr12  = 'WE_b';         DebugOutUni12  = '(deg)';     DebugOutData(12)  = DebugVar%WE_b
+        DebugOutStr13  = 'WE_t';         DebugOutUni13  = '(Nm)';      DebugOutData(13)  = DebugVar%WE_t
+        DebugOutStr14  = 'WE_w';         DebugOutUni14  = '(rad/s)';   DebugOutData(14)  = DebugVar%WE_w
+        DebugOutStr15  = 'WE_Vm';        DebugOutUni15  = '(m/s)';     DebugOutData(15)  = DebugVar%WE_Vm
+        DebugOutStr16  = 'WE_Vt';        DebugOutUni16  = '(m/s)';     DebugOutData(16)  = DebugVar%WE_Vt
+        DebugOutStr17  = 'WE_Cp';        DebugOutUni17  = '(-)';       DebugOutData(17)  = DebugVar%WE_Cp
+        DebugOutStr18  = 'WE_lambda';    DebugOutUni18  = '(rad/s)';   DebugOutData(18)  = DebugVar%WE_lambda
+        DebugOutStr19  = 'WE_F12';       DebugOutUni19  = '(-)';       DebugOutData(19)  = DebugVar%WE_F12
+        DebugOutStr20  = 'WE_F13';       DebugOutUni20  = '(-)';       DebugOutData(20)  = DebugVar%WE_F13
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
         DebugOutStrings =   [CHARACTER(10)  :: DebugOutStr1, DebugOutStr2, DebugOutStr3, DebugOutStr4, &
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
-                                                DebugOutStr9, DebugOutStr10, DebugOutStr11, DebugOutStr12]
+                                                DebugOutStr9, DebugOutStr10, DebugOutStr11, DebugOutStr12, &
+                                                DebugOutStr13, DebugOutStr14, DebugOutStr15, DebugOutStr16, &
+                                                DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
-                                                DebugOutUni9, DebugOutUni10, DebugOutUni11, DebugOutUni12]
+                                                DebugOutUni9, DebugOutUni10, DebugOutUni11, DebugOutUni12, &
+                                                DebugOutUni13, DebugOutUni14, DebugOutUni15, DebugOutUni1, &
+                                                DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -216,16 +216,15 @@ TYPE, PUBLIC :: PerformanceData
     REAL(8), DIMENSION(:,:), ALLOCATABLE    :: Cq_mat
 END TYPE PerformanceData
 
-TYPE, PUBLIC :: DebugVariables
-    REAL(8)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_b                         ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_w                         ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_t                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_Vm                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_Vt                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_lambda                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_F12                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_F13                         ! Torque that WSE uses, for debug purposes [-]
+TYPE, PUBLIC :: DebugVariables                                          
+! Variables used for debug purposes
+    REAL(8)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_b                         ! Pitch that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_w                         ! Rotor Speed that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_t                         ! Torque that WSE uses[-]
+    REAL(8)                             :: WE_Vm                        ! Mean wind speed component in WSE [m/s]
+    REAL(8)                             :: WE_Vt                        ! Turbulent wind speed component in WSE [m/s]
+    REAL(8)                             :: WE_lambda                    ! TSR in WSE [rad]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -185,7 +185,6 @@ TYPE, PUBLIC :: LocalVariables
     REAL(4)                             :: WE_Vw                        ! Estimated wind speed [m/s]
     REAL(4)                             :: WE_VwI                       ! Integrated wind speed quantity for estimation [m/s]
     REAL(4)                             :: WE_VwIdot                    ! Differentiated integrated wind speed quantity for estimation [m/s]
-    REAL(4)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
     REAL(4)                             :: Y_AccErr                     ! Accumulated yaw error [rad].
     REAL(4)                             :: Y_ErrLPFFast                 ! Filtered yaw error by fast low pass filter [rad].
     REAL(4)                             :: Y_ErrLPFSlow                 ! Filtered yaw error by slow low pass filter [rad].
@@ -213,5 +212,9 @@ TYPE, PUBLIC :: PerformanceData
     REAL(4), DIMENSION(:,:), ALLOCATABLE    :: Ct_mat
     REAL(4), DIMENSION(:,:), ALLOCATABLE    :: Cq_mat
 END TYPE PerformanceData
+
+TYPE, PUBLIC :: DebugVariables
+    REAL(4)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
+END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -219,7 +219,9 @@ END TYPE PerformanceData
 
 TYPE, PUBLIC :: DebugVariables
     REAL(4)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(4)                             :: WE_Pitch                       ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_b                       ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_w                       ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_t                      ! Torque that WSE uses, for debug purposes [-]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -129,7 +129,6 @@ TYPE, PUBLIC :: ControlParameters
     REAL(4)                             :: PC_RtTq99                    ! 99% of the rated torque value, using for switching between pitch and torque control, [Nm].
     REAL(4)                             :: VS_MaxOMTq                   ! Maximum torque at the end of the below-rated region 2, [Nm]
     REAL(4)                             :: VS_MinOMTq                   ! Minimum torque at the beginning of the below-rated region 2, [Nm]
-    REAL(4)                             :: VS_Rgn3Pitch                 ! Pitch angle at which the state machine switches to region 3, [rad].
 
 END TYPE ControlParameters
 
@@ -184,6 +183,7 @@ TYPE, PUBLIC :: LocalVariables
     REAL(4)                             :: VS_SpdErrBr                  ! Current speed error for region 1.5 PI controller (generator torque control) [rad/s].
     REAL(4)                             :: VS_SpdErr                    ! Current speed error for tip-speed-ratio tracking controller (generator torque control) [rad/s].
     INTEGER(4)                          :: VS_State                     ! State of the torque control system
+    REAL(4)                             :: VS_Rgn3Pitch                 ! Pitch angle at which the state machine switches to region 3, [rad].
     REAL(4)                             :: WE_Vw                        ! Estimated wind speed [m/s]
     REAL(4)                             :: WE_Vw_F                      ! Filtered estimated wind speed [m/s]
     REAL(4)                             :: WE_VwI                       ! Integrated wind speed quantity for estimation [m/s]

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -154,6 +154,7 @@ TYPE, PUBLIC :: LocalVariables
     REAL(4)                             :: FA_AccHPF                    ! High-pass filtered fore-aft acceleration [m/s^2]
     REAL(4)                             :: FA_AccHPFI                   ! Tower velocity, high-pass filtered and integrated fore-aft acceleration [m/s]
     REAL(4)                             :: FA_PitCom(3)                 ! Tower fore-aft vibration damping pitch contribution [rad]
+    REAL(4)                             :: RotSpeedF                    ! Filtered LSS (generator) speed [rad/s].
     REAL(4)                             :: GenSpeedF                    ! Filtered HSS (generator) speed [rad/s].
     REAL(4)                             :: GenTq                        ! Electrical generator torque, [Nm].
     REAL(4)                             :: GenTqMeas                    ! Measured generator torque [Nm]
@@ -168,6 +169,7 @@ TYPE, PUBLIC :: LocalVariables
     REAL(4)                             :: PC_MaxPit                    ! Maximum pitch setting in pitch controller (variable) [rad].
     REAL(4)                             :: PC_MinPit                    ! Minimum pitch setting in pitch controller (variable) [rad].
     REAL(4)                             :: PC_PitComT                   ! Total command pitch based on the sum of the proportional and integral terms [rad].
+    REAL(4)                             :: PC_PitComTF                   ! Filtered Total command pitch based on the sum of the proportional and integral terms [rad].
     REAL(4)                             :: PC_PitComT_IPC(3)            ! Total command pitch based on the sum of the proportional and integral terms, including IPC term [rad].
     REAL(4)                             :: PC_PwrErr                    ! Power error with respect to rated power [W]
     REAL(4)                             :: PC_SineExcitation            ! Sine contribution to pitch signal
@@ -183,8 +185,10 @@ TYPE, PUBLIC :: LocalVariables
     REAL(4)                             :: VS_SpdErr                    ! Current speed error for tip-speed-ratio tracking controller (generator torque control) [rad/s].
     INTEGER(4)                          :: VS_State                     ! State of the torque control system
     REAL(4)                             :: WE_Vw                        ! Estimated wind speed [m/s]
+    REAL(4)                             :: WE_Vw_F                      ! Filtered estimated wind speed [m/s]
     REAL(4)                             :: WE_VwI                       ! Integrated wind speed quantity for estimation [m/s]
     REAL(4)                             :: WE_VwIdot                    ! Differentiated integrated wind speed quantity for estimation [m/s]
+    REAL(4)                             :: VS_LastGenTrqF               ! Differentiated integrated wind speed quantity for estimation [m/s]
     REAL(4)                             :: Y_AccErr                     ! Accumulated yaw error [rad].
     REAL(4)                             :: Y_ErrLPFFast                 ! Filtered yaw error by fast low pass filter [rad].
     REAL(4)                             :: Y_ErrLPFSlow                 ! Filtered yaw error by slow low pass filter [rad].

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -215,6 +215,7 @@ END TYPE PerformanceData
 
 TYPE, PUBLIC :: DebugVariables
     REAL(4)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(4)                             :: WE_Pitch                       ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -222,6 +222,7 @@ TYPE, PUBLIC :: DebugVariables
     REAL(4)                             :: WE_b                       ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
     REAL(4)                             :: WE_w                       ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
     REAL(4)                             :: WE_t                      ! Torque that WSE uses, for debug purposes [-]
+    REAL(4)                             :: WE_D                      ! Torque that WSE uses, for debug purposes [-]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -26,178 +26,177 @@ TYPE, PUBLIC :: ControlParameters
     
     INTEGER(4)                          :: F_LPFType                    ! {1: first-order low-pass filter, 2: second-order low-pass filter}, [rad/s] 
     INTEGER(4)                          :: F_NotchType                  ! Notch on the measured generator speed {0: disable, 1: enable} 
-    REAL(4)                             :: F_LPFCornerFreq              ! Corner frequency (-3dB point) in the first-order low-pass filter, [rad/s]
-    REAL(4)                             :: F_LPFDamping                 ! Damping coefficient [used only when F_FilterType = 2]
-    REAL(4)                             :: F_NotchCornerFreq            ! Natural frequency of the notch filter, [rad/s]
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: F_NotchBetaNumDen            ! These two notch damping values (numerator and denominator) determines the width and depth of the notch
-    Real(4)                             :: F_SSCornerFreq               ! Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
-    Real(4)                             :: F_FlCornerFreq               ! Corner frequency (-3dB point) in the second order low pass filter of the tower-top fore-aft motion for floating feedback control [rad/s].
-    Real(4)                             :: F_FlDamping                  ! Damping constant in the first order low pass filter of the tower-top fore-aft motion for floating feedback control [-].
-    Real(4)                             :: F_FlpCornerFreq              ! Corner frequency (-3dB point) in the second order low pass filter of the blade root bending moment for flap control [rad/s].
-    Real(4)                             :: F_FlpDamping                 ! Damping constant in the first order low pass filter of the blade root bending moment for flap control[-].
+    REAL(8)                             :: F_LPFCornerFreq              ! Corner frequency (-3dB point) in the first-order low-pass filter, [rad/s]
+    REAL(8)                             :: F_LPFDamping                 ! Damping coefficient [used only when F_FilterType = 2]
+    REAL(8)                             :: F_NotchCornerFreq            ! Natural frequency of the notch filter, [rad/s]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: F_NotchBetaNumDen            ! These two notch damping values (numerator and denominator) determines the width and depth of the notch
+    REAL(8)                             :: F_SSCornerFreq               ! Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
+    REAL(8)                             :: F_FlCornerFreq               ! Corner frequency (-3dB point) in the second order low pass filter of the tower-top fore-aft motion for floating feedback control [rad/s].
+    REAL(8)                             :: F_FlDamping                  ! Damping constant in the first order low pass filter of the tower-top fore-aft motion for floating feedback control [-].
+    REAL(8)                             :: F_FlpCornerFreq              ! Corner frequency (-3dB point) in the second order low pass filter of the blade root bending moment for flap control [rad/s].
+    REAL(8)                             :: F_FlpDamping                 ! Damping constant in the first order low pass filter of the blade root bending moment for flap control[-].
 
-    REAL(4)                             :: FA_HPFCornerFreq             ! Corner frequency (-3dB point) in the high-pass filter on the fore-aft acceleration signal [rad/s]
-    REAL(4)                             :: FA_IntSat                    ! Integrator saturation (maximum signal amplitude contrbution to pitch from FA damper), [rad]
-    REAL(4)                             :: FA_KI                        ! Integral gain for the fore-aft tower damper controller, -1 = off / >0 = on [rad s/m]
+    REAL(8)                             :: FA_HPFCornerFreq             ! Corner frequency (-3dB point) in the high-pass filter on the fore-aft acceleration signal [rad/s]
+    REAL(8)                             :: FA_IntSat                    ! Integrator saturation (maximum signal amplitude contrbution to pitch from FA damper), [rad]
+    REAL(8)                             :: FA_KI                        ! Integral gain for the fore-aft tower damper controller, -1 = off / >0 = on [rad s/m]
     
     INTEGER(4)                          :: IPC_ControlMode              ! Turn Individual Pitch Control (IPC) for fatigue load reductions (pitch contribution) {0: off, 1: 1P reductions, 2: 1P+2P reductions}
-    REAL(4)                             :: IPC_IntSat                   ! Integrator saturation (maximum signal amplitude contrbution to pitch from IPC)
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: IPC_KI                       ! Integral gain for the individual pitch controller, [-]. 8E-10
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: IPC_aziOffset                ! Phase offset added to the azimuth angle for the individual pitch controller, [rad].
-    REAL(4)                             :: IPC_CornerFreqAct            ! Corner frequency of the first-order actuators model, to induce a phase lag in the IPC signal {0: Disable}, [rad/s]
+    REAL(8)                             :: IPC_IntSat                   ! Integrator saturation (maximum signal amplitude contrbution to pitch from IPC)
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: IPC_KI                       ! Integral gain for the individual pitch controller, [-]. 8E-10
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: IPC_aziOffset                ! Phase offset added to the azimuth angle for the individual pitch controller, [rad].
+    REAL(8)                             :: IPC_CornerFreqAct            ! Corner frequency of the first-order actuators model, to induce a phase lag in the IPC signal {0: Disable}, [rad/s]
     
     INTEGER(4)                          :: PC_ControlMode               ! Blade pitch control mode {0: No pitch, fix to fine pitch, 1: active PI blade pitch control}
     INTEGER(4)                          :: PC_GS_n                      ! Amount of gain-scheduling table entries
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: PC_GS_angles                 ! Gain-schedule table: pitch angles
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: PC_GS_KP                     ! Gain-schedule table: pitch controller kp gains
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: PC_GS_KI                     ! Gain-schedule table: pitch controller ki gains
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: PC_GS_KD                     ! Gain-schedule table: pitch controller kd gains
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: PC_GS_TF                     ! Gain-schedule table: pitch controller tf gains (derivative filter)
-    REAL(4)                             :: PC_MaxPit                    ! Maximum physical pitch limit, [rad].
-    REAL(4)                             :: PC_MinPit                    ! Minimum physical pitch limit, [rad].
-    REAL(4)                             :: PC_MaxRat                    ! Maximum pitch rate (in absolute value) in pitch controller, [rad/s].
-    REAL(4)                             :: PC_MinRat                    ! Minimum pitch rate (in absolute value) in pitch controller, [rad/s].
-    REAL(4)                             :: PC_RefSpd                    ! Desired (reference) HSS speed for pitch controller, [rad/s].
-    REAL(4)                             :: PC_FinePit                   ! Record 5: Below-rated pitch angle set-point (deg) [used only with Bladed Interface]
-    REAL(4)                             :: PC_Switch                    ! Angle above lowest minimum pitch angle for switch [rad]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: PC_GS_angles                 ! Gain-schedule table: pitch angles
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: PC_GS_KP                     ! Gain-schedule table: pitch controller kp gains
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: PC_GS_KI                     ! Gain-schedule table: pitch controller ki gains
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: PC_GS_KD                     ! Gain-schedule table: pitch controller kd gains
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: PC_GS_TF                     ! Gain-schedule table: pitch controller tf gains (derivative filter)
+    REAL(8)                             :: PC_MaxPit                    ! Maximum physical pitch limit, [rad].
+    REAL(8)                             :: PC_MinPit                    ! Minimum physical pitch limit, [rad].
+    REAL(8)                             :: PC_MaxRat                    ! Maximum pitch rate (in absolute value) in pitch controller, [rad/s].
+    REAL(8)                             :: PC_MinRat                    ! Minimum pitch rate (in absolute value) in pitch controller, [rad/s].
+    REAL(8)                             :: PC_RefSpd                    ! Desired (reference) HSS speed for pitch controller, [rad/s].
+    REAL(8)                             :: PC_FinePit                   ! Record 5: Below-rated pitch angle set-point (deg) [used only with Bladed Interface]
+    REAL(8)                             :: PC_Switch                    ! Angle above lowest minimum pitch angle for switch [rad]
     
     INTEGER(4)                          :: VS_ControlMode               ! Generator torque control mode in above rated conditions {0: constant torque, 1: constant power}
-    REAL(4)                             :: VS_GenEff                    ! Generator efficiency mechanical power -> electrical power [-]
-    REAL(4)                             :: VS_ArSatTq                   ! Above rated generator torque PI control saturation, [Nm] -- 212900
-    REAL(4)                             :: VS_MaxRat                    ! Maximum torque rate (in absolute value) in torque controller, [Nm/s].
-    REAL(4)                             :: VS_MaxTq                     ! Maximum generator torque in Region 3 (HSS side), [Nm]. -- chosen to be 10% above VS_RtTq
-    REAL(4)                             :: VS_MinTq                     ! Minimum generator (HSS side), [Nm].
-    REAL(4)                             :: VS_MinOMSpd                  ! Optimal mode minimum speed, [rad/s]
-    REAL(4)                             :: VS_Rgn2K                     ! Generator torque constant in Region 2 (HSS side), N-m/(rad/s)^2
-    REAL(4)                             :: VS_RtPwr                     ! Wind turbine rated power [W]
-    REAL(4)                             :: VS_RtTq                      ! Rated torque, [Nm].
-    REAL(4)                             :: VS_RefSpd                    ! Rated generator speed [rad/s]
+    REAL(8)                             :: VS_GenEff                    ! Generator efficiency mechanical power -> electrical power [-]
+    REAL(8)                             :: VS_ArSatTq                   ! Above rated generator torque PI control saturation, [Nm] -- 212900
+    REAL(8)                             :: VS_MaxRat                    ! Maximum torque rate (in absolute value) in torque controller, [Nm/s].
+    REAL(8)                             :: VS_MaxTq                     ! Maximum generator torque in Region 3 (HSS side), [Nm]. -- chosen to be 10% above VS_RtTq
+    REAL(8)                             :: VS_MinTq                     ! Minimum generator (HSS side), [Nm].
+    REAL(8)                             :: VS_MinOMSpd                  ! Optimal mode minimum speed, [rad/s]
+    REAL(8)                             :: VS_Rgn2K                     ! Generator torque constant in Region 2 (HSS side), N-m/(rad/s)^2
+    REAL(8)                             :: VS_RtPwr                     ! Wind turbine rated power [W]
+    REAL(8)                             :: VS_RtTq                      ! Rated torque, [Nm].
+    REAL(8)                             :: VS_RefSpd                    ! Rated generator speed [rad/s]
     INTEGER(4)                          :: VS_n                         ! Number of controller gains
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: VS_KP                        ! Proportional gain for generator PI torque controller, used in the transitional 2.5 region
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: VS_KI                        ! Integral gain for generator PI torque controller, used in the transitional 2.5 region
-    REAL(4)                             :: VS_TSRopt                    ! Power-maximizing region 2 tip-speed ratio [rad]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: VS_KP                        ! Proportional gain for generator PI torque controller, used in the transitional 2.5 region
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: VS_KI                        ! Integral gain for generator PI torque controller, used in the transitional 2.5 region
+    REAL(8)                             :: VS_TSRopt                    ! Power-maximizing region 2 tip-speed ratio [rad]
     
     INTEGER(4)                          :: SS_Mode                      ! Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
-    REAL(4)                             :: SS_VSGain                    ! Variable speed torque controller setpoint smoother gain, [-].
-    REAL(4)                             :: SS_PCGain                    ! Collective pitch controller setpoint smoother gain, [-].
+    REAL(8)                             :: SS_VSGain                    ! Variable speed torque controller setpoint smoother gain, [-].
+    REAL(8)                             :: SS_PCGain                    ! Collective pitch controller setpoint smoother gain, [-].
 
     INTEGER(4)                          :: WE_Mode                      ! Wind speed estimator mode {0: One-second low pass filtered hub height wind speed, 1: Imersion and Invariance Estimator (Ortega et al.)
-    REAL(4)                             :: WE_BladeRadius               ! Blade length [m]
+    REAL(8)                             :: WE_BladeRadius               ! Blade length [m]
     INTEGER(4)                          :: WE_CP_n                      ! Amount of parameters in the Cp array
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: WE_CP                        ! Parameters that define the parameterized CP(\lambda) function
-    REAL(4)                             :: WE_Gamma                     ! Adaption gain of the wind speed estimator algorithm [m/rad]
-    REAL(4)                             :: WE_GearboxRatio              ! Gearbox ratio, >=1  [-]
-    REAL(4)                             :: WE_Jtot                      ! Total drivetrain inertia, including blades, hub and casted generator inertia to LSS [kg m^2]
-    REAL(4)                             :: WE_RhoAir                    ! Air density [kg m^-3]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: WE_CP                        ! Parameters that define the parameterized CP(\lambda) function
+    REAL(8)                             :: WE_Gamma                     ! Adaption gain of the wind speed estimator algorithm [m/rad]
+    REAL(8)                             :: WE_GearboxRatio              ! Gearbox ratio, >=1  [-]
+    REAL(8)                             :: WE_Jtot                      ! Total drivetrain inertia, including blades, hub and casted generator inertia to LSS [kg m^2]
+    REAL(8)                             :: WE_RhoAir                    ! Air density [kg m^-3]
     CHARACTER(1024)                     :: PerfFileName                 ! File containing rotor performance tables (Cp,Ct,Cq)
     INTEGER(4), DIMENSION(:), ALLOCATABLE  :: PerfTableSize             ! Size of rotor performance tables, first number refers to number of blade pitch angles, second number referse to number of tip-speed ratios
     INTEGER(4)                          :: WE_FOPoles_N                 ! Number of first-order system poles used in EKF
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: WE_FOPoles_v                 ! Wind speeds corresponding to first-order system poles [m/s]
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: WE_FOPoles                   ! First order system poles
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: WE_FOPoles_v                 ! Wind speeds corresponding to first-order system poles [m/s]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: WE_FOPoles                   ! First order system poles
 
     INTEGER(4)                          :: Y_ControlMode                ! Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
-    REAL(4)                             :: Y_ErrThresh                  ! Error threshold [rad]. Turbine begins to yaw when it passes this. (104.71975512) -- 1.745329252
-    REAL(4)                             :: Y_IPC_IntSat                 ! Integrator saturation (maximum signal amplitude contrbution to pitch from yaw-by-IPC)
+    REAL(8)                             :: Y_ErrThresh                  ! Error threshold [rad]. Turbine begins to yaw when it passes this. (104.71975512) -- 1.745329252
+    REAL(8)                             :: Y_IPC_IntSat                 ! Integrator saturation (maximum signal amplitude contrbution to pitch from yaw-by-IPC)
     INTEGER(4)                          :: Y_IPC_n                      ! Number of controller gains (yaw-by-IPC)
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: Y_IPC_KP                     ! Yaw-by-IPC proportional controller gain Kp
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: Y_IPC_KI                     ! Yaw-by-IPC integral controller gain Ki
-    REAL(4)                             :: Y_IPC_omegaLP                ! Low-pass filter corner frequency for the Yaw-by-IPC controller to filtering the yaw alignment error, [rad/s].
-    REAL(4)                             :: Y_IPC_zetaLP                 ! Low-pass filter damping factor for the Yaw-by-IPC controller to filtering the yaw alignment error, [-].
-    REAL(4)                             :: Y_MErrSet                    ! Yaw alignment error, setpoint [rad]
-    REAL(4)                             :: Y_omegaLPFast                ! Corner frequency fast low pass filter, 1.0 [Hz]
-    REAL(4)                             :: Y_omegaLPSlow                ! Corner frequency slow low pass filter, 1/60 [Hz]
-    REAL(4)                             :: Y_Rate                       ! Yaw rate [rad/s]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: Y_IPC_KP                     ! Yaw-by-IPC proportional controller gain Kp
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: Y_IPC_KI                     ! Yaw-by-IPC integral controller gain Ki
+    REAL(8)                             :: Y_IPC_omegaLP                ! Low-pass filter corner frequency for the Yaw-by-IPC controller to filtering the yaw alignment error, [rad/s].
+    REAL(8)                             :: Y_IPC_zetaLP                 ! Low-pass filter damping factor for the Yaw-by-IPC controller to filtering the yaw alignment error, [-].
+    REAL(8)                             :: Y_MErrSet                    ! Yaw alignment error, setpoint [rad]
+    REAL(8)                             :: Y_omegaLPFast                ! Corner frequency fast low pass filter, 1.0 [Hz]
+    REAL(8)                             :: Y_omegaLPSlow                ! Corner frequency slow low pass filter, 1/60 [Hz]
+    REAL(8)                             :: Y_Rate                       ! Yaw rate [rad/s]
     
     INTEGER(4)                          :: PS_Mode                      ! Pitch saturation mode {0: no peak shaving, 1: implement pitch saturation}
     INTEGER(4)                          :: PS_BldPitchMin_N             ! Number of values in minimum blade pitch lookup table (should equal number of values in PS_WindSpeeds and PS_BldPitchMin)
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: PS_WindSpeeds                ! Wind speeds corresponding to minimum blade pitch angles [m/s]
-    REAL(4), DIMENSION(:), ALLOCATABLE  :: PS_BldPitchMin               ! Minimum blade pitch angles [rad]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: PS_WindSpeeds                ! Wind speeds corresponding to minimum blade pitch angles [m/s]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: PS_BldPitchMin               ! Minimum blade pitch angles [rad]
 
     INTEGER(4)                          :: SD_Mode                      ! Shutdown mode {0: no shutdown procedure, 1: pitch to max pitch at shutdown}
-    REAL(4)                             :: SD_MaxPit                    ! Maximum blade pitch angle to initiate shutdown, [rad]
-    REAL(4)                             :: SD_CornerFreq                ! Cutoff Frequency for first order low-pass filter for blade pitch angle, [rad/s]
+    REAL(8)                             :: SD_MaxPit                    ! Maximum blade pitch angle to initiate shutdown, [rad]
+    REAL(8)                             :: SD_CornerFreq                ! Cutoff Frequency for first order low-pass filter for blade pitch angle, [rad/s]
     
     INTEGER(4)                          :: Fl_Mode                      ! Floating specific feedback mode {0: no nacelle velocity feedback, 1: nacelle velocity feedback}
-    REAL(4)                             :: Fl_Kp                        ! Nacelle velocity proportional feedback gain [s]
+    REAL(8)                             :: Fl_Kp                        ! Nacelle velocity proportional feedback gain [s]
 
     INTEGER(4)                          :: Flp_Mode                     ! Flap actuator mode {0: off, 1: fixed flap position, 2: PI flap control}
-    REAL(4)                             :: Flp_Angle                    ! Fixed flap angle (degrees)
-    REAL(4)                             :: Flp_Kp                       ! PI flap control proportional gain 
-    REAL(4)                             :: Flp_Ki                       ! PI flap control integral gain 
-    REAL(4)                             :: Flp_MaxPit                   ! Maximum (and minimum) flap pitch angle [rad]
+    REAL(8)                             :: Flp_Angle                    ! Fixed flap angle (degrees)
+    REAL(8)                             :: Flp_Kp                       ! PI flap control proportional gain 
+    REAL(8)                             :: Flp_Ki                       ! PI flap control integral gain 
+    REAL(8)                             :: Flp_MaxPit                   ! Maximum (and minimum) flap pitch angle [rad]
     
-    REAL(4)                             :: PC_RtTq99                    ! 99% of the rated torque value, using for switching between pitch and torque control, [Nm].
-    REAL(4)                             :: VS_MaxOMTq                   ! Maximum torque at the end of the below-rated region 2, [Nm]
-    REAL(4)                             :: VS_MinOMTq                   ! Minimum torque at the beginning of the below-rated region 2, [Nm]
+    REAL(8)                             :: PC_RtTq99                    ! 99% of the rated torque value, using for switching between pitch and torque control, [Nm].
+    REAL(8)                             :: VS_MaxOMTq                   ! Maximum torque at the end of the below-rated region 2, [Nm]
+    REAL(8)                             :: VS_MinOMTq                   ! Minimum torque at the beginning of the below-rated region 2, [Nm]
 
 END TYPE ControlParameters
 
 TYPE, PUBLIC :: LocalVariables
     ! ---------- From avrSWAP ----------
     INTEGER(4)                      :: iStatus
-    REAL(4)                      :: Time
-    REAL(4)                      :: DT
-    REAL(4)                      :: VS_GenPwr
-    REAL(4)                      :: GenSpeed
-    REAL(4)                      :: RotSpeed
-    REAL(4)                      :: Y_M
-    REAL(4)                      :: HorWindV
-    REAL(4)                      :: rootMOOP(3)
-    REAL(4)                      :: BlPitch(3)
-    REAL(4)                      :: Azimuth
+    REAL(8)                      :: Time
+    REAL(8)                      :: DT
+    REAL(8)                      :: VS_GenPwr
+    REAL(8)                      :: GenSpeed
+    REAL(8)                      :: RotSpeed
+    REAL(8)                      :: Y_M
+    REAL(8)                      :: HorWindV
+    REAL(8)                      :: rootMOOP(3)
+    REAL(8)                      :: BlPitch(3)
+    REAL(8)                      :: Azimuth
     INTEGER(4)                   :: NumBl
-    REAL(4)                      :: FA_Acc                       ! Tower fore-aft acceleration [m/s^2]
-    REAL(4)                      :: NacIMU_FA_Acc                       ! Tower fore-aft acceleration [rad/s^2]
+    REAL(8)                      :: FA_Acc                       ! Tower fore-aft acceleration [m/s^2]
+    REAL(8)                      :: NacIMU_FA_Acc                       ! Tower fore-aft acceleration [rad/s^2]
 
     ! ---------- -Internal controller variables ----------
-    REAL(4)                             :: FA_AccHPF                    ! High-pass filtered fore-aft acceleration [m/s^2]
-    REAL(4)                             :: FA_AccHPFI                   ! Tower velocity, high-pass filtered and integrated fore-aft acceleration [m/s]
-    REAL(4)                             :: FA_PitCom(3)                 ! Tower fore-aft vibration damping pitch contribution [rad]
-    REAL(4)                             :: RotSpeedF                    ! Filtered LSS (generator) speed [rad/s].
-    REAL(4)                             :: GenSpeedF                    ! Filtered HSS (generator) speed [rad/s].
-    REAL(4)                             :: GenTq                        ! Electrical generator torque, [Nm].
-    REAL(4)                             :: GenTqMeas                    ! Measured generator torque [Nm]
-    REAL(4)                             :: GenArTq                      ! Electrical generator torque, for above-rated PI-control [Nm].
-    REAL(4)                             :: GenBrTq                      ! Electrical generator torque, for below-rated PI-control [Nm].
-    INTEGER(4)                          :: GlobalState                  ! Current global state to determine the behavior of the different controllers [-].
-    REAL(4)                             :: IPC_PitComF(3)               ! Commanded pitch of each blade as calculated by the individual pitch controller, F stands for low-pass filtered [rad].
-    REAL(4)                             :: PC_KP                        ! Proportional gain for pitch controller at rated pitch (zero) [s].
-    REAL(4)                             :: PC_KI                        ! Integral gain for pitch controller at rated pitch (zero) [-].
-    REAL(4)                             :: PC_KD                        ! Differential gain for pitch controller at rated pitch (zero) [-].
-    REAL(4)                             :: PC_TF                        ! First-order filter parameter for derivative action
-    REAL(4)                             :: PC_MaxPit                    ! Maximum pitch setting in pitch controller (variable) [rad].
-    REAL(4)                             :: PC_MinPit                    ! Minimum pitch setting in pitch controller (variable) [rad].
-    REAL(4)                             :: PC_PitComT                   ! Total command pitch based on the sum of the proportional and integral terms [rad].
-    REAL(4)                             :: PC_PitComTF                   ! Filtered Total command pitch based on the sum of the proportional and integral terms [rad].
-    REAL(4)                             :: PC_PitComT_IPC(3)            ! Total command pitch based on the sum of the proportional and integral terms, including IPC term [rad].
-    REAL(4)                             :: PC_PwrErr                    ! Power error with respect to rated power [W]
-    REAL(4)                             :: PC_SineExcitation            ! Sine contribution to pitch signal
-    REAL(4)                             :: PC_SpdErr                    ! Current speed error (pitch control) [rad/s].
+    REAL(8)                             :: FA_AccHPF                    ! High-pass filtered fore-aft acceleration [m/s^2]
+    REAL(8)                             :: FA_AccHPFI                   ! Tower velocity, high-pass filtered and integrated fore-aft acceleration [m/s]
+    REAL(8)                             :: FA_PitCom(3)                 ! Tower fore-aft vibration damping pitch contribution [rad]
+    REAL(8)                             :: RotSpeedF                    ! Filtered LSS (generator) speed [rad/s].
+    REAL(8)                             :: GenSpeedF                    ! Filtered HSS (generator) speed [rad/s].
+    REAL(8)                             :: GenTq                        ! Electrical generator torque, [Nm].
+    REAL(8)                             :: GenTqMeas                    ! Measured generator torque [Nm]
+    REAL(8)                             :: GenArTq                      ! Electrical generator torque, for above-rated PI-control [Nm].
+    REAL(8)                             :: GenBrTq                      ! Electrical generator torque, for below-rated PI-control [Nm].
+    REAL(8)                             :: IPC_PitComF(3)               ! Commanded pitch of each blade as calculated by the individual pitch controller, F stands for low-pass filtered [rad].
+    REAL(8)                             :: PC_KP                        ! Proportional gain for pitch controller at rated pitch (zero) [s].
+    REAL(8)                             :: PC_KI                        ! Integral gain for pitch controller at rated pitch (zero) [-].
+    REAL(8)                             :: PC_KD                        ! Differential gain for pitch controller at rated pitch (zero) [-].
+    REAL(8)                             :: PC_TF                        ! First-order filter parameter for derivative action
+    REAL(8)                             :: PC_MaxPit                    ! Maximum pitch setting in pitch controller (variable) [rad].
+    REAL(8)                             :: PC_MinPit                    ! Minimum pitch setting in pitch controller (variable) [rad].
+    REAL(8)                             :: PC_PitComT                   ! Total command pitch based on the sum of the proportional and integral terms [rad].
+    REAL(8)                             :: PC_PitComTF                   ! Filtered Total command pitch based on the sum of the proportional and integral terms [rad].
+    REAL(8)                             :: PC_PitComT_IPC(3)            ! Total command pitch based on the sum of the proportional and integral terms, including IPC term [rad].
+    REAL(8)                             :: PC_PwrErr                    ! Power error with respect to rated power [W]
+    REAL(8)                             :: PC_SineExcitation            ! Sine contribution to pitch signal
+    REAL(8)                             :: PC_SpdErr                    ! Current speed error (pitch control) [rad/s].
     INTEGER(4)                          :: PC_State                     ! State of the pitch control system
-    REAL(4)                             :: PitCom(3)                    ! Commanded pitch of each blade the last time the controller was called [rad].
-    REAL(4)                             :: SS_DelOmegaF                 ! Filtered setpoint shifting term defined in setpoint smoother [rad/s].
-    REAL(4)                             :: TestType                     ! Test variable, no use
-    REAL(4)                             :: VS_LastGenTrq                ! Commanded electrical generator torque the last time the controller was called [Nm].
-    REAL(4)                             :: VS_MechGenPwr                ! Mechanical power on the generator axis [W]
-    REAL(4)                             :: VS_SpdErrAr                  ! Current speed error for region 2.5 PI controller (generator torque control) [rad/s].
-    REAL(4)                             :: VS_SpdErrBr                  ! Current speed error for region 1.5 PI controller (generator torque control) [rad/s].
-    REAL(4)                             :: VS_SpdErr                    ! Current speed error for tip-speed-ratio tracking controller (generator torque control) [rad/s].
+    REAL(8)                             :: PitCom(3)                    ! Commanded pitch of each blade the last time the controller was called [rad].
+    REAL(8)                             :: SS_DelOmegaF                 ! Filtered setpoint shifting term defined in setpoint smoother [rad/s].
+    REAL(8)                             :: TestType                     ! Test variable, no use
+    REAL(8)                             :: VS_LastGenTrq                ! Commanded electrical generator torque the last time the controller was called [Nm].
+    REAL(8)                             :: VS_MechGenPwr                ! Mechanical power on the generator axis [W]
+    REAL(8)                             :: VS_SpdErrAr                  ! Current speed error for region 2.5 PI controller (generator torque control) [rad/s].
+    REAL(8)                             :: VS_SpdErrBr                  ! Current speed error for region 1.5 PI controller (generator torque control) [rad/s].
+    REAL(8)                             :: VS_SpdErr                    ! Current speed error for tip-speed-ratio tracking controller (generator torque control) [rad/s].
     INTEGER(4)                          :: VS_State                     ! State of the torque control system
-    REAL(4)                             :: VS_Rgn3Pitch                 ! Pitch angle at which the state machine switches to region 3, [rad].
-    REAL(4)                             :: WE_Vw                        ! Estimated wind speed [m/s]
-    REAL(4)                             :: WE_Vw_F                      ! Filtered estimated wind speed [m/s]
-    REAL(4)                             :: WE_VwI                       ! Integrated wind speed quantity for estimation [m/s]
-    REAL(4)                             :: WE_VwIdot                    ! Differentiated integrated wind speed quantity for estimation [m/s]
-    REAL(4)                             :: VS_LastGenTrqF               ! Differentiated integrated wind speed quantity for estimation [m/s]
-    REAL(4)                             :: Y_AccErr                     ! Accumulated yaw error [rad].
-    REAL(4)                             :: Y_ErrLPFFast                 ! Filtered yaw error by fast low pass filter [rad].
-    REAL(4)                             :: Y_ErrLPFSlow                 ! Filtered yaw error by slow low pass filter [rad].
-    REAL(4)                             :: Y_MErr                       ! Measured yaw error, measured + setpoint [rad].
-    REAL(4)                             :: Y_YawEndT                    ! Yaw end time [s]. Indicates the time up until which yaw is active with a fixed rate
+    REAL(8)                             :: VS_Rgn3Pitch                 ! Pitch angle at which the state machine switches to region 3, [rad].
+    REAL(8)                             :: WE_Vw                        ! Estimated wind speed [m/s]
+    REAL(8)                             :: WE_Vw_F                      ! Filtered estimated wind speed [m/s]
+    REAL(8)                             :: WE_VwI                       ! Integrated wind speed quantity for estimation [m/s]
+    REAL(8)                             :: WE_VwIdot                    ! Differentiated integrated wind speed quantity for estimation [m/s]
+    REAL(8)                             :: VS_LastGenTrqF               ! Differentiated integrated wind speed quantity for estimation [m/s]
+    REAL(8)                             :: Y_AccErr                     ! Accumulated yaw error [rad].
+    REAL(8)                             :: Y_ErrLPFFast                 ! Filtered yaw error by fast low pass filter [rad].
+    REAL(8)                             :: Y_ErrLPFSlow                 ! Filtered yaw error by slow low pass filter [rad].
+    REAL(8)                             :: Y_MErr                       ! Measured yaw error, measured + setpoint [rad].
+    REAL(8)                             :: Y_YawEndT                    ! Yaw end time [s]. Indicates the time up until which yaw is active with a fixed rate
     LOGICAL(1)                          :: SD                           ! Shutdown, .FALSE. if inactive, .TRUE. if active
-    REAL(4)                             :: Fl_PitCom                           ! Shutdown, .FALSE. if inactive, .TRUE. if active
-    REAL(4)                             :: NACIMU_FA_AccF
-    REAL(4)                             :: Flp_Angle(3)                 ! Flap Angle (rad)
+    REAL(8)                             :: Fl_PitCom                           ! Shutdown, .FALSE. if inactive, .TRUE. if active
+    REAL(8)                             :: NACIMU_FA_AccF
+    REAL(8)                             :: Flp_Angle(3)                 ! Flap Angle (rad)
     END TYPE LocalVariables
 
 TYPE, PUBLIC :: ObjectInstances
@@ -210,19 +209,23 @@ TYPE, PUBLIC :: ObjectInstances
 END TYPE ObjectInstances
 
 TYPE, PUBLIC :: PerformanceData
-    REAL(4), DIMENSION(:), ALLOCATABLE      :: TSR_vec
-    REAL(4), DIMENSION(:), ALLOCATABLE      :: Beta_vec
-    REAL(4), DIMENSION(:,:), ALLOCATABLE    :: Cp_mat
-    REAL(4), DIMENSION(:,:), ALLOCATABLE    :: Ct_mat
-    REAL(4), DIMENSION(:,:), ALLOCATABLE    :: Cq_mat
+    REAL(8), DIMENSION(:), ALLOCATABLE      :: TSR_vec
+    REAL(8), DIMENSION(:), ALLOCATABLE      :: Beta_vec
+    REAL(8), DIMENSION(:,:), ALLOCATABLE    :: Cp_mat
+    REAL(8), DIMENSION(:,:), ALLOCATABLE    :: Ct_mat
+    REAL(8), DIMENSION(:,:), ALLOCATABLE    :: Cq_mat
 END TYPE PerformanceData
 
 TYPE, PUBLIC :: DebugVariables
-    REAL(4)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(4)                             :: WE_b                       ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(4)                             :: WE_w                       ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(4)                             :: WE_t                      ! Torque that WSE uses, for debug purposes [-]
-    REAL(4)                             :: WE_D                      ! Torque that WSE uses, for debug purposes [-]
+    REAL(8)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(8)                             :: WE_b                         ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(8)                             :: WE_w                         ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
+    REAL(8)                             :: WE_t                         ! Torque that WSE uses, for debug purposes [-]
+    REAL(8)                             :: WE_Vm                         ! Torque that WSE uses, for debug purposes [-]
+    REAL(8)                             :: WE_Vt                         ! Torque that WSE uses, for debug purposes [-]
+    REAL(8)                             :: WE_lambda                         ! Torque that WSE uses, for debug purposes [-]
+    REAL(8)                             :: WE_F12                         ! Torque that WSE uses, for debug purposes [-]
+    REAL(8)                             :: WE_F13                         ! Torque that WSE uses, for debug purposes [-]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -548,8 +548,6 @@ CONTAINS
                      'https://github.com/NREL/ROSCO                                                 '//NEW_LINE('A')// &
                      '------------------------------------------------------------------------------'
 
-                ! print *, 'Version 1.0.1: pretty debug'
-
             CALL ReadControlParameterFileSub(CntrPar, accINFILE, NINT(avrSWAP(50)))
 
             IF (CntrPar%WE_Mode > 0) THEN
@@ -559,16 +557,12 @@ CONTAINS
             LocalVar%TestType = 0
         
             ! Initialize the SAVED variables:
-
-            ! DO K = 1,LocalVar%NumBl
             LocalVar%PitCom = LocalVar%BlPitch ! This will ensure that the variable speed controller picks the correct control region and the pitch controller picks the correct gain on the first call
-            ! END DO
-            
             LocalVar%Y_AccErr = 0.0  ! This will ensure that the accumulated yaw error starts at zero
             LocalVar%Y_YawEndT = -1.0 ! This will ensure that the initial yaw end time is lower than the actual time to prevent initial yawing
             
-            ! Wind speed estimator initialization, we always assume an initial wind speed of 10 m/s
-            LocalVar%WE_Vw = 10
+            ! Wind speed estimator initialization
+            LocalVar%WE_Vw = LocalVar%HorWindV
             LocalVar%WE_VwI = LocalVar%WE_Vw - CntrPar%WE_Gamma*LocalVar%RotSpeed
             
             ! Setpoint Smoother initialization to zero

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -215,7 +215,6 @@ CONTAINS
         CntrPar%PC_RtTq99 = CntrPar%VS_RtTq*0.99
         CntrPar%VS_MinOMTq = CntrPar%VS_Rgn2K*CntrPar%VS_MinOMSpd**2
         CntrPar%VS_MaxOMTq = CntrPar%VS_Rgn2K*CntrPar%VS_RefSpd**2
-        CntrPar%VS_Rgn3Pitch = CntrPar%PC_FinePit + CntrPar%PC_Switch
         
         CLOSE(UnControllerParameters)
         
@@ -283,8 +282,10 @@ CONTAINS
         ! Define transition region setpoint errors
         LocalVar%VS_SpdErrAr = VS_RefSpd - LocalVar%GenSpeedF               ! Current speed error - Region 2.5 PI-control (Above Rated)
         LocalVar%VS_SpdErrBr = CntrPar%VS_MinOMSpd - LocalVar%GenSpeedF     ! Current speed error - Region 1.5 PI-control (Below Rated)
-    
-    
+        
+        ! Region 3 minimum pitch angle for state machine
+        LocalVar%VS_Rgn3Pitch = LocalVar%PC_MinPit + CntrPar%PC_Switch
+
     END SUBROUTINE ComputeVariablesSetpoints
     ! -----------------------------------------------------------------------------------
     ! Read avrSWAP array passed from ServoDyn    

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -236,7 +236,6 @@ CONTAINS
         REAL(4)                                 :: VS_RefSpd        ! Referece speed for variable speed torque controller, [rad/s] 
         REAL(4)                                 :: PC_RefSpd        ! Referece speed for pitch controller, [rad/s] 
         REAL(4)                                 :: Omega_op         ! Optimal TSR-tracking generator speed, [rad/s]
-        REAL(4)                                 :: WE_Vw_f          ! Filtered Wind Speed Estimate
         ! temp
         ! REAL(4)                                 :: VS_TSRop = 7.5
 
@@ -257,9 +256,7 @@ CONTAINS
         ! ----- Torque controller reference errors -----
         ! Define VS reference generator speed [rad/s]
         IF (CntrPar%VS_ControlMode == 2) THEN
-            ! WE_Vw_f = LPFilter(LocalVar%We_Vw, LocalVar%DT, 0.625, LocalVar%iStatus, .FALSE., objInst%instLPF)
-            WE_Vw_f = LocalVar%We_Vw
-            VS_RefSpd = (CntrPar%VS_TSRopt * WE_Vw_f / CntrPar%WE_BladeRadius) * CntrPar%WE_GearboxRatio
+            VS_RefSpd = (CntrPar%VS_TSRopt * LocalVar%We_Vw_F / CntrPar%WE_BladeRadius) * CntrPar%WE_GearboxRatio
             VS_RefSpd = saturate(VS_RefSpd,CntrPar%VS_MinOMSpd, CntrPar%VS_RefSpd)
         ELSE
             VS_RefSpd = CntrPar%VS_RefSpd
@@ -404,12 +401,12 @@ CONTAINS
         
         IF (CntrPar%VS_KP(1) > 0.0) THEN
             aviFAIL = -1
-            ErrMsg  = 'VS_KP must be greater than zero.'
+            ErrMsg  = 'VS_KP must be less than zero.'
         ENDIF
         
         IF (CntrPar%VS_KI(1) > 0.0) THEN
             aviFAIL = -1
-            ErrMsg  = 'VS_KI must be greater than zero.'
+            ErrMsg  = 'VS_KI must be less than zero.'
         ENDIF
         
         IF (CntrPar%PC_RefSpd <= 0.0) THEN

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -267,7 +267,7 @@ CONTAINS
 
         ! Force zero torque in shutdown mode
         IF (LocalVar%SD) THEN
-            VS_RefSpd = CntrPar%VS_MinOMSpd * CntrPar%WE_GearboxRatio
+            VS_RefSpd = CntrPar%VS_MinOMSpd
         ENDIF
 
         ! Force minimum rotor speed
@@ -280,7 +280,7 @@ CONTAINS
 
         ! Define transition region setpoint errors
         LocalVar%VS_SpdErrAr = VS_RefSpd - LocalVar%GenSpeedF               ! Current speed error - Region 2.5 PI-control (Above Rated)
-        LocalVar%VS_SpdErrBr = CntrPar%VS_MinOMSpd * CntrPar%WE_GearboxRatio - LocalVar%GenSpeedF     ! Current speed error - Region 1.5 PI-control (Below Rated)
+        LocalVar%VS_SpdErrBr = CntrPar%VS_MinOMSpd - LocalVar%GenSpeedF     ! Current speed error - Region 1.5 PI-control (Below Rated)
         
         ! Region 3 minimum pitch angle for state machine
         LocalVar%VS_Rgn3Pitch = LocalVar%PC_MinPit + CntrPar%PC_Switch

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -215,7 +215,6 @@ CONTAINS
         CntrPar%PC_RtTq99 = CntrPar%VS_RtTq*0.99
         CntrPar%VS_MinOMTq = CntrPar%VS_Rgn2K*CntrPar%VS_MinOMSpd**2
         CntrPar%VS_MaxOMTq = CntrPar%VS_Rgn2K*CntrPar%VS_RefSpd**2
-        
         CLOSE(UnControllerParameters)
         
         !------------------- HOUSEKEEPING -----------------------
@@ -226,7 +225,7 @@ CONTAINS
     ! Calculate setpoints for primary control actions    
     SUBROUTINE ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
         USE ROSCO_Types, ONLY : ControlParameters, LocalVariables, ObjectInstances
-        
+        USE Constants
         ! Allocate variables
         TYPE(ControlParameters), INTENT(INOUT)  :: CntrPar
         TYPE(LocalVariables), INTENT(INOUT)     :: LocalVar
@@ -268,7 +267,7 @@ CONTAINS
 
         ! Force zero torque in shutdown mode
         IF (LocalVar%SD) THEN
-            VS_RefSpd = CntrPar%VS_MinOMSpd
+            VS_RefSpd = CntrPar%VS_MinOMSpd * CntrPar%WE_GearboxRatio
         ENDIF
 
         ! Force minimum rotor speed
@@ -281,7 +280,7 @@ CONTAINS
 
         ! Define transition region setpoint errors
         LocalVar%VS_SpdErrAr = VS_RefSpd - LocalVar%GenSpeedF               ! Current speed error - Region 2.5 PI-control (Above Rated)
-        LocalVar%VS_SpdErrBr = CntrPar%VS_MinOMSpd - LocalVar%GenSpeedF     ! Current speed error - Region 1.5 PI-control (Below Rated)
+        LocalVar%VS_SpdErrBr = CntrPar%VS_MinOMSpd * CntrPar%WE_GearboxRatio - LocalVar%GenSpeedF     ! Current speed error - Region 1.5 PI-control (Below Rated)
         
         ! Region 3 minimum pitch angle for state machine
         LocalVar%VS_Rgn3Pitch = LocalVar%PC_MinPit + CntrPar%PC_Switch

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -231,11 +231,11 @@ CONTAINS
         TYPE(LocalVariables), INTENT(INOUT)     :: LocalVar
         TYPE(ObjectInstances), INTENT(INOUT)    :: objInst
 
-        REAL(4)                                 :: VS_RefSpd        ! Referece speed for variable speed torque controller, [rad/s] 
-        REAL(4)                                 :: PC_RefSpd        ! Referece speed for pitch controller, [rad/s] 
-        REAL(4)                                 :: Omega_op         ! Optimal TSR-tracking generator speed, [rad/s]
+        REAL(8)                                 :: VS_RefSpd        ! Referece speed for variable speed torque controller, [rad/s] 
+        REAL(8)                                 :: PC_RefSpd        ! Referece speed for pitch controller, [rad/s] 
+        REAL(8)                                 :: Omega_op         ! Optimal TSR-tracking generator speed, [rad/s]
         ! temp
-        ! REAL(4)                                 :: VS_TSRop = 7.5
+        ! REAL(8)                                 :: VS_TSRop = 7.5
 
         ! ----- Calculate yaw misalignment error -----
         LocalVar%Y_MErr = LocalVar%Y_M + CntrPar%Y_MErrSet ! Yaw-alignment error

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -549,7 +549,24 @@ CONTAINS
                      '                                                Jan-Willem van Wingerden      '//NEW_LINE('A')// &
                      'Visit our GitHub-page to contribute to this project:                          '//NEW_LINE('A')// &
                      'https://github.com/NREL/ROSCO                                                 '//NEW_LINE('A')// &
+                     '                                                                              '//NEW_LINE('A')// &
                      '------------------------------------------------------------------------------'
+
+                print *, 'Version 1.0.1: pretty debug'
+
+            ! ErrMsg = '                                                                              '//NEW_LINE('A')// &
+            !          '------------------------------------------------------------------------------'//NEW_LINE('A')// &
+            !          'Running a controller implemented through NREL''s ROSCO Toolbox                    '//NEW_LINE('A')// &
+            !          'A wind turbine controller framework for public use in the scientific field    '//NEW_LINE('A')// &
+            !          'Developed in collaboration: National Renewable Energy Laboratory              '//NEW_LINE('A')// &
+            !          '                            Delft University of Technology, The Netherlands   '//NEW_LINE('A')// &
+            !          '                                                                              '//NEW_LINE('A')// &
+            !          'Visit our GitHub-page to contribute to this project:                          '//NEW_LINE('A')// &
+            !          'https://github.com/NREL/ROSCO                                                 '//NEW_LINE('A')// &
+            !          '                                                                              '//NEW_LINE('A')// &
+            !          'Version: 1.0.0                                                                '//NEW_LINE('A')// &
+            !          '------------------------------------------------------------------------------'
+
             CALL ReadControlParameterFileSub(CntrPar, accINFILE, NINT(avrSWAP(50)))
 
             IF (CntrPar%WE_Mode > 0) THEN

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -549,23 +549,9 @@ CONTAINS
                      '                                                Jan-Willem van Wingerden      '//NEW_LINE('A')// &
                      'Visit our GitHub-page to contribute to this project:                          '//NEW_LINE('A')// &
                      'https://github.com/NREL/ROSCO                                                 '//NEW_LINE('A')// &
-                     '                                                                              '//NEW_LINE('A')// &
                      '------------------------------------------------------------------------------'
 
-                print *, 'Version 1.0.1: pretty debug'
-
-            ! ErrMsg = '                                                                              '//NEW_LINE('A')// &
-            !          '------------------------------------------------------------------------------'//NEW_LINE('A')// &
-            !          'Running a controller implemented through NREL''s ROSCO Toolbox                    '//NEW_LINE('A')// &
-            !          'A wind turbine controller framework for public use in the scientific field    '//NEW_LINE('A')// &
-            !          'Developed in collaboration: National Renewable Energy Laboratory              '//NEW_LINE('A')// &
-            !          '                            Delft University of Technology, The Netherlands   '//NEW_LINE('A')// &
-            !          '                                                                              '//NEW_LINE('A')// &
-            !          'Visit our GitHub-page to contribute to this project:                          '//NEW_LINE('A')// &
-            !          'https://github.com/NREL/ROSCO                                                 '//NEW_LINE('A')// &
-            !          '                                                                              '//NEW_LINE('A')// &
-            !          'Version: 1.0.0                                                                '//NEW_LINE('A')// &
-            !          '------------------------------------------------------------------------------'
+                ! print *, 'Version 1.0.1: pretty debug'
 
             CALL ReadControlParameterFileSub(CntrPar, accINFILE, NINT(avrSWAP(50)))
 


### PR DESCRIPTION
Some upgrades here - I think all good!

Major updates:
- @dzalkind implemented a really nice debug routine. This sets a precedent for a good standard. Now, if `LoggingLevel >= 1` in the DISCON.IN file, ROSCO will print a file titled `<root_name>.RO.dbg`. Debug parameters can be updated via the debug routine in functions.py, providing a nice way to look at the internal signals of the controller. 
- Everything was moved to double precision. This mostly helps the filter parameter consistency for varied timesteps, especially as the timesteps get small. 
- Bug fixes in the wind speed estimator help the evolution of the mean wind speed state stay on track. This looks like a sign flip, really. 

Minor updates:
- some small updates to parameters, cleanup, and versioning