### PR TITLE
f/constant power

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ Scripts/CompileDISCONHereCopyRun\.cmd
 *~
 .DS_Store
 *.u2d
+*.swp
+*.i90
 
 # vs code
 .vscode

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -254,7 +254,7 @@ CONTAINS
         ! ------ Setpoint Smoothing ------
         IF ( CntrPar%SS_Mode == 1) THEN
             ! Find setpoint shift amount
-            DelOmega = ((LocalVar%PC_PitComT - CntrPar%PC_MinPit)/0.524) * CntrPar%SS_VSGain - ((LocalVar%VS_MaxTq - LocalVar%VS_LastGenTrq))/LocalVar%VS_MaxTq * CntrPar%SS_PCGain ! Normalize to 30 degrees for now
+            DelOmega = ((LocalVar%PC_PitComT - CntrPar%PC_MinPit)/0.524) * CntrPar%SS_VSGain - ((LocalVar%VS_GenPwr - LocalVar%VS_LastGenTrq))/CntrPar%VS_RtPwr * CntrPar%SS_PCGain ! Normalize to 30 degrees for now
             DelOmega = DelOmega * CntrPar%PC_RefSpd
             ! Filter
             LocalVar%SS_DelOmegaF = LPFilter(DelOmega, LocalVar%DT, CntrPar%F_SSCornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF) 

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -277,7 +277,7 @@ CONTAINS
         TYPE(DebugVariables), INTENT(INOUT)     :: DebugVar
 
         ! Define minimum blade pitch angle as a function of estimated wind speed
-        PitchSaturation = interp1d(CntrPar%PS_WindSpeeds, CntrPar%PS_BldPitchMin, LocalVar%WE_Vw_F)
+        PitchSaturation = interp1d(CntrPar%PS_WindSpeeds, CntrPar%PS_BldPitchMin, LocalVar%WE_Vw)
 
     END FUNCTION PitchSaturation
 !-------------------------------------------------------------------------------------------------------------------------------

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -254,7 +254,7 @@ CONTAINS
         ! ------ Setpoint Smoothing ------
         IF ( CntrPar%SS_Mode == 1) THEN
             ! Find setpoint shift amount
-            DelOmega = ((LocalVar%PC_PitComT - CntrPar%PC_MinPit)/0.524) * CntrPar%SS_VSGain - ((CntrPar%VS_RtTq - LocalVar%VS_LastGenTrq))/CntrPar%VS_RtTq * CntrPar%SS_PCGain ! Normalize to 30 degrees for now
+            DelOmega = ((LocalVar%PC_PitComT - CntrPar%PC_MinPit)/0.524) * CntrPar%SS_VSGain - ((LocalVar%VS_MaxTq - LocalVar%VS_LastGenTrq))/LocalVar%VS_MaxTq * CntrPar%SS_PCGain ! Normalize to 30 degrees for now
             DelOmega = DelOmega * CntrPar%PC_RefSpd
             ! Filter
             LocalVar%SS_DelOmegaF = LPFilter(DelOmega, LocalVar%DT, CntrPar%F_SSCornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF) 

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -277,7 +277,7 @@ CONTAINS
         TYPE(DebugVariables), INTENT(INOUT)     :: DebugVar
 
         ! Define minimum blade pitch angle as a function of estimated wind speed
-        PitchSaturation = interp1d(CntrPar%PS_WindSpeeds, CntrPar%PS_BldPitchMin, LocalVar%WE_Vw)
+        PitchSaturation = interp1d(CntrPar%PS_WindSpeeds, CntrPar%PS_BldPitchMin, LocalVar%WE_Vw_F)
 
     END FUNCTION PitchSaturation
 !-------------------------------------------------------------------------------------------------------------------------------

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -106,8 +106,8 @@ CONTAINS
         ENDIF
 
         ! Saturate collective pitch commands:
-        LocalVar%PC_PitComT = ratelimit(LocalVar%PC_PitComT, PitComT_Last, CntrPar%PC_MinRat, CntrPar%PC_MaxRat, LocalVar%DT) ! Saturate the overall command of blade K using the pitch rate limit
         LocalVar%PC_PitComT = saturate(LocalVar%PC_PitComT, LocalVar%PC_MinPit, CntrPar%PC_MaxPit)                    ! Saturate the overall command using the pitch angle limits
+        LocalVar%PC_PitComT = ratelimit(LocalVar%PC_PitComT, PitComT_Last, CntrPar%PC_MinRat, CntrPar%PC_MaxRat, LocalVar%DT) ! Saturate the overall command of blade K using the pitch rate limit
         PitComT_Last = LocalVar%PC_PitComT
 
         ! Combine and saturate all individual pitch commands:

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -157,7 +157,7 @@ CONTAINS
         IF ((CntrPar%VS_ControlMode == 2) .OR. (CntrPar%VS_ControlMode == 3)) THEN
             ! Constant Power, update VS_MaxTq
             IF (CntrPar%VS_ControlMode == 3) THEN
-                VS_MaxTq = min((CntrPar%VS_RtPwr/(CntrPar%VS_GenEff/100.0))/LocalVar%GenSpeedF, CntrPar%VS_RtTq)
+                VS_MaxTq = min((CntrPar%VS_RtPwr/(CntrPar%VS_GenEff/100.0))/LocalVar%GenSpeedF, CntrPar%VS_MaxTq)
             END IF
 
             ! PI controller

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -50,6 +50,7 @@ CONTAINS
         REAL(C_FLOAT), INTENT(INOUT)    :: avrSWAP(*)   ! The swap array, used to pass data to, and receive data from the DLL controller.
         INTEGER(4)                      :: K            ! Index used for looping through blades.
         REAL(8), Save                :: PitComT_Last 
+        REAL(8), Save                :: PC_PitComT_F
 
         ! ------- Blade Pitch Controller --------
         ! Load PC State
@@ -59,11 +60,13 @@ CONTAINS
             LocalVar%PC_MaxPit = CntrPar%PC_FinePit
         END IF
 
+        PC_PitComT_F = LPFilter(LocalVar%PC_PitComT, LocalVar%DT, CntrPar%F_LPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF)
+        
         ! Compute (interpolate) the gains based on previously commanded blade pitch angles and lookup table:
-        LocalVar%PC_KP = interp1d(CntrPar%PC_GS_angles, CntrPar%PC_GS_KP, LocalVar%PC_PitComT) ! Proportional gain
-        LocalVar%PC_KI = interp1d(CntrPar%PC_GS_angles, CntrPar%PC_GS_KI, LocalVar%PC_PitComT) ! Integral gain
-        LocalVar%PC_KD = interp1d(CntrPar%PC_GS_angles, CntrPar%PC_GS_KD, LocalVar%PC_PitComT) ! Derivative gain
-        LocalVar%PC_TF = interp1d(CntrPar%PC_GS_angles, CntrPar%PC_GS_TF, LocalVar%PC_PitComT) ! TF gains (derivative filter) !NJA - need to clarify
+        LocalVar%PC_KP = interp1d(CntrPar%PC_GS_angles, CntrPar%PC_GS_KP, PC_PitComT_F) ! Proportional gain
+        LocalVar%PC_KI = interp1d(CntrPar%PC_GS_angles, CntrPar%PC_GS_KI, PC_PitComT_F) ! Integral gain
+        LocalVar%PC_KD = interp1d(CntrPar%PC_GS_angles, CntrPar%PC_GS_KD, PC_PitComT_F) ! Derivative gain
+        LocalVar%PC_TF = interp1d(CntrPar%PC_GS_angles, CntrPar%PC_GS_TF, PC_PitComT_F) ! TF gains (derivative filter) !NJA - need to clarify
         
         ! Compute the collective pitch command associated with the proportional and integral gains:
         IF (LocalVar%iStatus == 0) THEN

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -154,7 +154,12 @@ CONTAINS
         ENDIF
 
         ! Optimal Tip-Speed-Ratio tracking controller
-        IF (CntrPar%VS_ControlMode == 2) THEN
+        IF ((CntrPar%VS_ControlMode == 2) .OR. (CntrPar%VS_ControlMode == 3)) THEN
+            ! Constant Power, update VS_MaxTq
+            IF (CntrPar%VS_ControlMode == 3) THEN
+                VS_MaxTq = min((CntrPar%VS_RtPwr/(CntrPar%VS_GenEff/100.0))/LocalVar%GenSpeedF, CntrPar%VS_RtTq)
+            END IF
+
             ! PI controller
             LocalVar%GenTq = PIController(LocalVar%VS_SpdErr, CntrPar%VS_KP(1), CntrPar%VS_KI(1), CntrPar%VS_MinTq, VS_MaxTq, LocalVar%DT, LocalVar%VS_LastGenTrq, .FALSE., objInst%instPI)
             LocalVar%GenTq = saturate(LocalVar%GenTq, CntrPar%VS_MinTq, VS_MaxTq)

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -296,7 +296,7 @@ CONTAINS
 
         ! Control commands (used by WSE, mostly)
         LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7, LocalVar%iStatus, .FALSE., objInst%instSecLPF)
-        LocalVar%PC_PitComTF = LPFilter(LocalVar%PC_PitComT, LocalVar%dt, CntrPar%F_LPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF)
+        LocalVar%PC_PitComTF    = SecLPFilter(LocalVar%PC_PitComT, LocalVar%DT, CntrPar%F_LPFCornerFreq*0.25, 0.7, LocalVar%iStatus, .FALSE., objInst%instLPF)
 
     END SUBROUTINE PreFilterMeasuredSignals
     END MODULE Filters

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -291,7 +291,7 @@ CONTAINS
         LocalVar%FA_AccHPF = HPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%FA_HPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instHPF)
         
         ! Filter Wind Speed Estimator Signal
-        LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.6283, LocalVar%iStatus,.FALSE.,objInst%instLPF) ! 30 second time constant
+        LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, LocalVar%iStatus,.FALSE.,objInst%instLPF) ! 30 second time constant
 
 
         ! Control commands (used by WSE, mostly)

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -291,7 +291,7 @@ CONTAINS
         LocalVar%FA_AccHPF = HPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%FA_HPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instHPF)
         
         ! Filter Wind Speed Estimator Signal
-        LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, LocalVar%iStatus,.FALSE.,objInst%instLPF) ! 30 second time constant
+        LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.6283, LocalVar%iStatus,.FALSE.,objInst%instLPF) ! 30 second time constant
 
 
         ! Control commands (used by WSE, mostly)

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -433,7 +433,7 @@ CONTAINS
         RotorArea = PI*CntrPar%WE_BladeRadius**2
         Lambda = LocalVar%RotSpeedF*CntrPar%WE_BladeRadius/LocalVar%WE_Vw
         ! Cp = CPfunction(CntrPar%WE_CP, Lambda)
-        Cp = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%PC_PitComTF*R2D, Lambda)
+        Cp = interp2d(PerfData%Beta_vec,PerfData%TSR_vec,PerfData%Cp_mat, LocalVar%PC_PitComT*R2D, Lambda)
         AeroDynTorque = 0.5*(CntrPar%WE_RhoAir*RotorArea)*(LocalVar%WE_Vw**3/LocalVar%RotSpeedF)*Cp
         AeroDynTorque = MAX(AeroDynTorque, 0.0)
         

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -226,6 +226,9 @@ TYPE, PUBLIC :: DebugVariables
     REAL(8)                             :: WE_Vm                        ! Mean wind speed component in WSE [m/s]
     REAL(8)                             :: WE_Vt                        ! Turbulent wind speed component in WSE [m/s]
     REAL(8)                             :: WE_lambda                    ! TSR in WSE [rad]
+    !
+    REAL(8)                             :: PC_PICommand                 
+
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -176,6 +176,7 @@ TYPE, PUBLIC :: LocalVariables
     REAL(8)                             :: PitCom(3)                    ! Commanded pitch of each blade the last time the controller was called [rad].
     REAL(8)                             :: SS_DelOmegaF                 ! Filtered setpoint shifting term defined in setpoint smoother [rad/s].
     REAL(8)                             :: TestType                     ! Test variable, no use
+    REAL(8)                             :: VS_MaxTq                     ! Maximum allowable generator torque [Nm].
     REAL(8)                             :: VS_LastGenTrq                ! Commanded electrical generator torque the last time the controller was called [Nm].
     REAL(8)                             :: VS_MechGenPwr                ! Mechanical power on the generator axis [W]
     REAL(8)                             :: VS_SpdErrAr                  ! Current speed error for region 2.5 PI controller (generator torque control) [rad/s].

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -61,7 +61,7 @@ TYPE, PUBLIC :: ControlParameters
     REAL(8)                             :: PC_FinePit                   ! Record 5: Below-rated pitch angle set-point (deg) [used only with Bladed Interface]
     REAL(8)                             :: PC_Switch                    ! Angle above lowest minimum pitch angle for switch [rad]
     
-    INTEGER(4)                          :: VS_ControlMode               ! Generator torque control mode in above rated conditions {0: constant torque, 1: constant power}
+    INTEGER(4)                          :: VS_ControlMode               ! Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR Tracking, 3: TSR Tracking w/ const power}
     REAL(8)                             :: VS_GenEff                    ! Generator efficiency mechanical power -> electrical power [-]
     REAL(8)                             :: VS_ArSatTq                   ! Above rated generator torque PI control saturation, [Nm] -- 212900
     REAL(8)                             :: VS_MaxRat                    ! Maximum torque rate (in absolute value) in torque controller, [Nm/s].

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -629,7 +629,7 @@ CONTAINS
         READ(UnPerfParameters, *) 
         ALLOCATE(PerfData%Cq_mat(CntrPar%PerfTableSize(1),CntrPar%PerfTableSize(2)))
         DO i = 1,CntrPar%PerfTableSize(2)
-            READ(UnPerfParameters, *) PerfData%Ct_mat(i,:) ! Read Cq table
+            READ(UnPerfParameters, *) PerfData%Cq_mat(i,:) ! Read Cq table
         END DO
     
     END SUBROUTINE ReadCpFile

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -253,7 +253,7 @@ CONTAINS
         
         ! ----- Torque controller reference errors -----
         ! Define VS reference generator speed [rad/s]
-        IF (CntrPar%VS_ControlMode == 2) THEN
+        IF ((CntrPar%VS_ControlMode == 2) .OR. (CntrPar%VS_ControlMode == 3)) THEN
             VS_RefSpd = (CntrPar%VS_TSRopt * LocalVar%We_Vw_F / CntrPar%WE_BladeRadius) * CntrPar%WE_GearboxRatio
             VS_RefSpd = saturate(VS_RefSpd,CntrPar%VS_MinOMSpd, CntrPar%VS_RefSpd)
         ELSE
@@ -274,7 +274,7 @@ CONTAINS
         VS_RefSpd = max(VS_RefSpd, CntrPar%VS_MinOmSpd)
 
         ! TSR-tracking reference error
-        IF (CntrPar%VS_ControlMode == 2) THEN
+        IF ((CntrPar%VS_ControlMode == 2) .OR. (CntrPar%VS_ControlMode == 3)) THEN
             LocalVar%VS_SpdErr = VS_RefSpd - LocalVar%GenSpeedF
         ENDIF
 


### PR DESCRIPTION
# Constant power

This is an updated version of #32. The primary changes enable constant power in above rated operation while using the TSR tracking controller in below rated operation. This is enabled by setting `VS_ControlMode=3` in the DISCON.IN file. 

Some other minor cleanup and changes are included. Of particular note is a filter on the blade pitch control signal that is used in the Wind Speed Estimator and to determine the gain schedule. This helps smooth the pitch controller response a bit. The filter is a second order LPF is hard-coded to have a cutoff frequency of 0.25*`F_CornerFreq` and a damping ration of 0.7. This should probably be included as an input in the next API change 