### PR TITLE
Fix setpoint smoother to use last gen pwr

### DIFF
--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -255,7 +255,7 @@ CONTAINS
         ! ------ Setpoint Smoothing ------
         IF ( CntrPar%SS_Mode == 1) THEN
             ! Find setpoint shift amount
-            DelOmega = ((LocalVar%PC_PitComT - CntrPar%PC_MinPit)/0.524) * CntrPar%SS_VSGain - ((LocalVar%VS_GenPwr - LocalVar%VS_LastGenTrq))/CntrPar%VS_RtPwr * CntrPar%SS_PCGain ! Normalize to 30 degrees for now
+            DelOmega = ((LocalVar%PC_PitComT - CntrPar%PC_MinPit)/0.524) * CntrPar%SS_VSGain - ((LocalVar%VS_GenPwr - LocalVar%VS_LastGenPwr))/CntrPar%VS_RtPwr * CntrPar%SS_PCGain ! Normalize to 30 degrees for now
             DelOmega = DelOmega * CntrPar%PC_RefSpd
             ! Filter
             LocalVar%SS_DelOmegaF = LPFilter(DelOmega, LocalVar%DT, CntrPar%F_SSCornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF) 

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -195,6 +195,7 @@ CONTAINS
         
         ! Reset the value of LocalVar%VS_LastGenTrq to the current values:
         LocalVar%VS_LastGenTrq = LocalVar%GenTq
+        LocalVar%VS_LastGenPwr = LocalVar%VS_GenPwr
         
         ! Set the command generator torque (See Appendix A of Bladed User's Guide):
         avrSWAP(47) = MAX(0.0, LocalVar%VS_LastGenTrq)  ! Demanded generator torque, prevent negatives.
@@ -407,9 +408,11 @@ CONTAINS
             
             ! Steady flap angle
             ELSEIF (CntrPar%Flp_Mode == 1) THEN
-                LocalVar%Flp_Angle(1) = LocalVar%Flp_Angle(1) 
-                LocalVar%Flp_Angle(2) = LocalVar%Flp_Angle(2) 
-                LocalVar%Flp_Angle(3) = LocalVar%Flp_Angle(3) 
+                IF (MOD(LocalVar%Time,10.0) == 0) THEN
+                    LocalVar%Flp_Angle(1) = LocalVar%Flp_Angle(1) + 1.0 * D2R
+                    LocalVar%Flp_Angle(2) = LocalVar%Flp_Angle(2) + 1.0 * D2R
+                    LocalVar%Flp_Angle(3) = LocalVar%Flp_Angle(3) + 1.0 * D2R
+                ENDIF
                 ! IF (MOD(LocalVar%Time,10.0) == 0) THEN
                 !     LocalVar%Flp_Angle(1) = LocalVar%Flp_Angle(1) + 1*D2R
                 !     LocalVar%Flp_Angle(2) = LocalVar%Flp_Angle(2) + 1*D2R

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -408,11 +408,9 @@ CONTAINS
             
             ! Steady flap angle
             ELSEIF (CntrPar%Flp_Mode == 1) THEN
-                IF (MOD(LocalVar%Time,10.0) == 0) THEN
-                    LocalVar%Flp_Angle(1) = LocalVar%Flp_Angle(1) + 1.0 * D2R
-                    LocalVar%Flp_Angle(2) = LocalVar%Flp_Angle(2) + 1.0 * D2R
-                    LocalVar%Flp_Angle(3) = LocalVar%Flp_Angle(3) + 1.0 * D2R
-                ENDIF
+                LocalVar%Flp_Angle(1) = LocalVar%Flp_Angle(1) 
+                LocalVar%Flp_Angle(2) = LocalVar%Flp_Angle(2) 
+                LocalVar%Flp_Angle(3) = LocalVar%Flp_Angle(3) 
                 ! IF (MOD(LocalVar%Time,10.0) == 0) THEN
                 !     LocalVar%Flp_Angle(1) = LocalVar%Flp_Angle(1) + 1*D2R
                 !     LocalVar%Flp_Angle(2) = LocalVar%Flp_Angle(2) + 1*D2R

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -178,6 +178,7 @@ TYPE, PUBLIC :: LocalVariables
     REAL(8)                             :: TestType                     ! Test variable, no use
     REAL(8)                             :: VS_MaxTq                     ! Maximum allowable generator torque [Nm].
     REAL(8)                             :: VS_LastGenTrq                ! Commanded electrical generator torque the last time the controller was called [Nm].
+    REAL(8)                             :: VS_LastGenPwr                ! Commanded electrical generator torque the last time the controller was called [Nm].
     REAL(8)                             :: VS_MechGenPwr                ! Mechanical power on the generator axis [W]
     REAL(8)                             :: VS_SpdErrAr                  ! Current speed error for region 2.5 PI controller (generator torque control) [rad/s].
     REAL(8)                             :: VS_SpdErrBr                  ! Current speed error for region 1.5 PI controller (generator torque control) [rad/s].


### PR DESCRIPTION
Small bug fix where the setpoint smoother used `VS_LastGenTrq` vs. `VS_LastGenPwr`