### PR TITLE
call shutdown routine last

### DIFF
--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -94,17 +94,18 @@ CONTAINS
             LocalVar%PC_MinPit = CntrPar%PC_FinePit
         ENDIF
 
-        ! Shutdown
-        IF (CntrPar%SD_Mode == 1) THEN
-            LocalVar%PC_PitComT = Shutdown(LocalVar, CntrPar, objInst)
-        ENDIF
-
+        
         ! FloatingFeedback
         IF (CntrPar%Fl_Mode == 1) THEN
             LocalVar%Fl_PitCom = FloatingFeedback(LocalVar, CntrPar, objInst)
             LocalVar%PC_PitComT = LocalVar%PC_PitComT + LocalVar%Fl_PitCom
         ENDIF
-
+        
+        ! Shutdown
+        IF (CntrPar%SD_Mode == 1) THEN
+            LocalVar%PC_PitComT = Shutdown(LocalVar, CntrPar, objInst)
+        ENDIF
+        
         ! Saturate collective pitch commands:
         LocalVar%PC_PitComT = saturate(LocalVar%PC_PitComT, LocalVar%PC_MinPit, CntrPar%PC_MaxPit)                    ! Saturate the overall command using the pitch angle limits
         LocalVar%PC_PitComT = ratelimit(LocalVar%PC_PitComT, PitComT_Last, CntrPar%PC_MinRat, CntrPar%PC_MaxRat, LocalVar%DT) ! Saturate the overall command of blade K using the pitch rate limit


### PR DESCRIPTION
## Description and Purpose
This fixes a bug when the shutdown controller gets over-ridden during FOWT operation

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Github issues addressed, if one exists
n/a
## Examples/Testing, if applicable
n/a, though we do need to test shutdown cases, clearly. 
