### PR TITLE
Updates based on WES reviewer comments

### DIFF
--- a/.github/workflows/CI_rosco-compile.yml
+++ b/.github/workflows/CI_rosco-compile.yml
@@ -3,6 +3,10 @@ name: CI_rosco-compile
 # We run CI on push commits on all branches
 on: [push, pull_request]
 
+# Specify FORTRAN compiler
+env:
+  FORTRAN_COMPILER: gfortran-10
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
@@ -24,15 +28,7 @@ jobs:
           miniconda-version: "latest"
           channels: conda-forge, general
           auto-update-conda: true
-          python-version: 3.8
-          environment-file: environment.yml
 
-      # Install compilers
-      - name: Add dependencies linux
-        if: false == contains( matrix.os, 'windows')
-        shell: pwsh
-        run: |
-          conda install -y compilers
 
       - name: Add dependencies windows 
         if: true == contains( matrix.os, 'windows')
@@ -40,25 +36,38 @@ jobs:
         run: |
           conda install -y m2w64-toolchain
 
-      # Install ROSCO linux
-      - name: Compile ROSCO linux
-        if: false == contains( matrix.os, 'windows')
-        shell: pwsh
-        run: |
-          cd ROSCO
-          mkdir build
-          cd build
-          cmake ..
-          make install
+      - name: Setup Workspace
+        run: cmake -E make_directory ${{runner.workspace}}/ROSCO/ROSCO/build
 
-      # Install ROSCO windows
-      - name: Compile ROSCO windows
-        if: true == contains( matrix.os, 'windows')
-        shell: pwsh
+      - name: Configure and Build - unix
+        if: false == contains( matrix.os, 'windows')
+        working-directory: ${{runner.workspace}}/ROSCO/ROSCO/build
         run: |
-          cd ROSCO
-          mkdir build
-          cd build
-          cmake .. -G "MinGW Makefiles" 
-          make install
+          cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/ROSCO/ROSCO/install \
+            -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
+            ..
+          cmake --build . --target install
+
+      - name: Configure and Build - windows
+        if: true == contains( matrix.os, 'windows')
+        working-directory: ${{runner.workspace}}/ROSCO/ROSCO/build
+        shell: bash -l {0}
+        run: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/ROSCO/ROSCO/install \
+            -G "MinGW Makefiles" \
+            .. 
+          cmake --build . --target install
+
+      # # Install ROSCO linux
+      # - name: Compile ROSCO linux
+      #   if: false == contains( matrix.os, 'windows')
+      #   working-directory: ${{runner.workspace}}/ROSCO/ROSCO/build
+
+      # # Install ROSCO windows
+      # - name: Compile ROSCO windows
+      #   if: true == contains( matrix.os, 'windows')
+      #   working-directory: ${{runner.workspace}}/ROSCO/ROSCO/build
+        # run: cmake --build . --target install -G "MinGW Makefiles" 
           

--- a/.github/workflows/CI_rosco-pytools.yml
+++ b/.github/workflows/CI_rosco-pytools.yml
@@ -3,6 +3,10 @@ name: CI_rosco-pytools
 # We run CI on push commits on all branches
 on: [push, pull_request]
 
+# Specify FORTRAN compiler
+env:
+  FORTRAN_COMPILER: gfortran-10
+  
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
@@ -34,16 +38,15 @@ jobs:
 
 
       # Install dependencies of ROSCO toolbox
-      - name: Add dependencies ubuntu specific
-        if: false == contains( matrix.os, 'windows')
-        run: |
-          conda install -y compilers
-          conda install -y wisdem
       - name: Add dependencies windows specific
         if: true == contains( matrix.os, 'windows')
         run: |
           conda install -y m2w64-toolchain libpython 
-          conda install -y wisdem
+
+      - name: Add dependencies macOS specific
+        if: true == contains( matrix.os, 'macOS')
+        run: |
+          conda install compilers
         
 
       # Install ROSCO toolbox
@@ -84,7 +87,6 @@ jobs:
       - name: Add dependencies ubuntu specific
         if: false == contains( matrix.os, 'windows')
         run: |
-          conda install -y compilers
           conda install -y wisdem
       - name: Add dependencies windows specific
         if: true == contains( matrix.os, 'windows')
@@ -141,7 +143,6 @@ jobs:
       - name: Add dependencies ubuntu specific
         if: false == contains( matrix.os, 'windows')
         run: |
-          conda install -y compilers
           conda install -y wisdem
         
 

--- a/ROSCO/src/Controllers.f90
+++ b/ROSCO/src/Controllers.f90
@@ -371,11 +371,17 @@ CONTAINS
         TYPE(LocalVariables), INTENT(IN)     :: LocalVar 
         TYPE(ObjectInstances), INTENT(INOUT)    :: objInst
         ! Allocate Variables 
-        REAL(8)                      :: FA_vel ! Tower fore-aft velocity
+        REAL(8)                      :: FA_vel ! Tower fore-aft velocity [m/s]
+        REAL(8)                      :: NacIMU_FA_vel ! Tower fore-aft pitching velocity [rad/s]
         
         ! Calculate floating contribution to pitch command
         FA_vel = PIController(LocalVar%FA_AccF, 0.0, 1.0, -100.0 , 100.0 ,LocalVar%DT, 0.0, .FALSE., objInst%instPI) ! NJA: should never reach saturation limits....
-        FloatingFeedback = (0.0 - FA_vel) * CntrPar%Fl_Kp !* LocalVar%PC_KP/maxval(CntrPar%PC_GS_KP)
+        NacIMU_FA_vel = PIController(LocalVar%NacIMU_FA_AccF, 0.0, 1.0, -100.0 , 100.0 ,LocalVar%DT, 0.0, .FALSE., objInst%instPI) ! NJA: should never reach saturation limits....
+        if (CntrPar%Fl_Mode == 1) THEN
+            FloatingFeedback = (0.0 - FA_vel) * CntrPar%Fl_Kp !* LocalVar%PC_KP/maxval(CntrPar%PC_GS_KP)
+        ELSEIF (CntrPar%Fl_Mode == 2) THEN
+            FloatingFeedback = (0.0 - NacIMU_FA_vel) * CntrPar%Fl_Kp !* LocalVar%PC_KP/maxval(CntrPar%PC_GS_KP)
+        END IF
 
     END FUNCTION FloatingFeedback
 !-------------------------------------------------------------------------------------------------------------------------------

--- a/ROSCO/src/Controllers.f90
+++ b/ROSCO/src/Controllers.f90
@@ -371,11 +371,11 @@ CONTAINS
         TYPE(LocalVariables), INTENT(IN)     :: LocalVar 
         TYPE(ObjectInstances), INTENT(INOUT)    :: objInst
         ! Allocate Variables 
-        REAL(8)                      :: NacIMU_FA_vel ! Tower fore-aft velocity
+        REAL(8)                      :: FA_vel ! Tower fore-aft velocity
         
         ! Calculate floating contribution to pitch command
-        NacIMU_FA_vel = PIController(LocalVar%NacIMU_FA_AccF, 0.0, 1.0, -100.0 , 100.0 ,LocalVar%DT, 0.0, .FALSE., objInst%instPI) ! NJA: should never reach saturation limits....
-        FloatingFeedback = (0.0 - NacIMU_FA_vel) * CntrPar%Fl_Kp !* LocalVar%PC_KP/maxval(CntrPar%PC_GS_KP)
+        FA_vel = PIController(LocalVar%FA_AccF, 0.0, 1.0, -100.0 , 100.0 ,LocalVar%DT, 0.0, .FALSE., objInst%instPI) ! NJA: should never reach saturation limits....
+        FloatingFeedback = (0.0 - FA_vel) * CntrPar%Fl_Kp !* LocalVar%PC_KP/maxval(CntrPar%PC_GS_KP)
 
     END FUNCTION FloatingFeedback
 !-------------------------------------------------------------------------------------------------------------------------------

--- a/ROSCO/src/Filters.f90
+++ b/ROSCO/src/Filters.f90
@@ -277,13 +277,17 @@ CONTAINS
             ! Force to start at 0
             IF (LocalVar%iStatus == 0) THEN
                 LocalVar%NacIMU_FA_AccF = SecLPFilter(0., LocalVar%DT, CntrPar%F_FlCornerFreq(1), CntrPar%F_FlCornerFreq(2), LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+                LocalVar%FA_AccF = SecLPFilter(0., LocalVar%DT, CntrPar%F_FlCornerFreq(1), CntrPar%F_FlCornerFreq(2), LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
             ELSE
                 LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq(1), CntrPar%F_FlCornerFreq(2), LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+                LocalVar%FA_AccF = SecLPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq(1), CntrPar%F_FlCornerFreq(2), LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
             ENDIF
             LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, 0.0167, LocalVar%iStatus, .FALSE., objInst%instHPF) 
+            LocalVar%FA_AccF = HPFilter(LocalVar%FA_AccF, LocalVar%DT, 0.0167, LocalVar%iStatus, .FALSE., objInst%instHPF) 
             
             IF (CntrPar%F_NotchType >= 2) THEN
                 LocalVar%NACIMU_FA_AccF = NotchFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, CntrPar%F_NotchCornerFreq, CntrPar%F_NotchBetaNumDen(1), CntrPar%F_NotchBetaNumDen(2), LocalVar%iStatus, .FALSE., objInst%instNotch) ! Fixed Damping
+                LocalVar%FA_AccF = NotchFilter(LocalVar%FA_AccF, LocalVar%DT, CntrPar%F_NotchCornerFreq, CntrPar%F_NotchBetaNumDen(1), CntrPar%F_NotchBetaNumDen(2), LocalVar%iStatus, .FALSE., objInst%instNotch) ! Fixed Damping
             ENDIF
         ENDIF
 

--- a/ROSCO/src/ROSCO_Types.f90
+++ b/ROSCO/src/ROSCO_Types.f90
@@ -198,6 +198,7 @@ TYPE, PUBLIC :: LocalVariables
     LOGICAL(1)                          :: SD                           ! Shutdown, .FALSE. if inactive, .TRUE. if active
     REAL(8)                             :: Fl_PitCom                           ! Shutdown, .FALSE. if inactive, .TRUE. if active
     REAL(8)                             :: NACIMU_FA_AccF
+    REAL(8)                             :: FA_AccF
     REAL(8)                             :: Flp_Angle(3)                 ! Flap Angle (rad)
     END TYPE LocalVariables
 

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -222,7 +222,10 @@ class Controller():
         Pi_wind         = 1/2 * rho * Ar * v**2 * dCt_dTSR * dlambda_dv + rho * Ar * v * Ct_op
 
         # Second order system coefficients
-        A = dtau_domega/J             # Plant pole
+        if self.VS_ControlMode in [0,2]: # Constant torque above rated
+            A = dtau_domega/J
+        else:                            # Constant power above rated
+            A = dtau_domega/J + Ng**2/J  * turbine.rated_power/(Ng**2*rated_rotor_speed**2)
         B_tau = -Ng**2/J              # Torque input  
         B_beta = dtau_dbeta/J         # Blade pitch input 
 

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -225,7 +225,8 @@ class Controller():
         if self.VS_ControlMode in [0,2]: # Constant torque above rated
             A = dtau_domega/J
         else:                            # Constant power above rated
-            A = dtau_domega/J + Ng**2/J  * turbine.rated_power/(Ng**2*rated_rotor_speed**2)
+            A = dtau_domega/J 
+            A[-len(v_above_rated)+1:] += Ng**2/J * turbine.rated_power/(Ng**2*rated_rotor_speed**2)
         B_tau = -Ng**2/J              # Torque input  
         B_beta = dtau_dbeta/J         # Blade pitch input 
 

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -308,7 +308,7 @@ class Controller():
         if self.Fl_Mode == 1: # Floating feedback
             # If we haven't set Kp_float as a control parameter
             if self.tune_Fl:
-                Kp_float = (dtau_dv/dtau_dbeta) * turbine.TowerHt * Ng 
+                Kp_float = (dtau_dv/dtau_dbeta) * Ng 
                 f_kp     = interpolate.interp1d(v,Kp_float)
                 self.Kp_float = f_kp(turbine.v_rated * (1.05))   # get Kp at v_rated + 0.5 m/s
                 # Turn on the notch filter if floating

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -153,7 +153,7 @@ class Controller():
         v = np.concatenate((v_below_rated, v_above_rated))
 
         # separate TSRs by operations regions
-        TSR_below_rated = np.ones(len(v_below_rated))*turbine.TSR_operational # below rated     
+        TSR_below_rated = [min(turbine.TSR_operational, rated_rotor_speed*R/v) for v in v_below_rated] # below rated     
         TSR_above_rated = rated_rotor_speed*R/v_above_rated                   # above rated
         # TSR_below_rated = np.minimum(np.max(TSR_above_rated), TSR_below_rated)
         TSR_op = np.concatenate((TSR_below_rated, TSR_above_rated))   # operational TSRs

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -308,10 +308,12 @@ class Controller():
             self.ps.min_pitch_saturation(self,turbine)
 
         # --- Floating feedback term ---
-        if self.Fl_Mode == 1: # Floating feedback
+        if self.Fl_Mode >= 1: # Floating feedback
             # If we haven't set Kp_float as a control parameter
             if self.tune_Fl:
                 Kp_float = (dtau_dv/dtau_dbeta) * Ng 
+                if self.Fl_Mode == 2:
+                    Kp_float *= turbine.TowerHt      
                 f_kp     = interpolate.interp1d(v,Kp_float)
                 self.Kp_float = f_kp(turbine.v_rated * (1.05))   # get Kp at v_rated + 0.5 m/s
                 # Turn on the notch filter if floating

--- a/ROSCO_toolbox/inputs/toolbox_schema.yaml
+++ b/ROSCO_toolbox/inputs/toolbox_schema.yaml
@@ -163,9 +163,9 @@ properties:
             Fl_Mode:            
                 type: number
                 minimum: 0
-                maximum: 1
+                maximum: 2
                 default: 0
-                description: Floating specific feedback mode (0- no nacelle velocity feedback, 1- nacelle velocity feedback)
+                description: Floating specific feedback mode (0- no nacelle velocity feedback, 1 - nacelle velocity feedback, 2 - nacelle pitching acceleration feedback)
             Flp_Mode:           
                 type: number
                 minimum: 0

--- a/ROSCO_toolbox/utilities.py
+++ b/ROSCO_toolbox/utilities.py
@@ -170,7 +170,11 @@ def write_DISCON(turbine, controller, param_file='DISCON.IN', txt_filename='Cp_C
     file.write('{:<014.5f}      ! SD_CornerFreq     - Cutoff Frequency for first order low-pass filter for blade pitch angle, [rad/s]\n'.format(controller.sd_cornerfreq))
     file.write('\n')
     file.write('!------- Floating -----------------------------------------------------------\n')
-    file.write('{:<014.5f}      ! Fl_Kp             - Nacelle velocity proportional feedback gain [s]\n'.format(controller.Kp_float))
+    if controller.Fl_Mode == 2:
+        floatstr = 'pitching'
+    else:
+        floatstr = 'velocity'
+    file.write('{:<014.5f}      ! Fl_Kp             - Nacelle {} proportional feedback gain [s]\n'.format(controller.Kp_float, floatstr))
     file.write('\n')
     file.write('!------- FLAP ACTUATION -----------------------------------------------------\n')
     file.write('{:<014.5f}      ! Flp_Angle         - Initial or steady state flap angle [rad]\n'.format(controller.flp_angle))

--- a/Test_Cases/NREL-5MW/DISCON.IN
+++ b/Test_Cases/NREL-5MW/DISCON.IN
@@ -8,7 +8,7 @@
 1                   ! F_LPFType			- {1: first-order low-pass filter, 2: second-order low-pass filter}, [rad/s] (currently filters generator speed and pitch control signals
 0                   ! F_NotchType		- Notch on the measured generator speed and/or tower fore-aft motion (for floating) {0: disable, 1: generator speed, 2: tower-top fore-aft motion, 3: generator speed and tower-top fore-aft motion}
 0                   ! IPC_ControlMode	- Turn Individual Pitch Control (IPC) for fatigue load reductions (pitch contribution) {0: off, 1: 1P reductions, 2: 1P+2P reductions}
-2                   ! VS_ControlMode	- Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR tracking PI control}
+3                   ! VS_ControlMode	- Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR tracking PI control}
 1                   ! PC_ControlMode    - Blade pitch control mode {0: No pitch, fix to fine pitch, 1: active PI blade pitch control}
 0                   ! Y_ControlMode		- Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
 1                   ! SS_Mode           - Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
@@ -28,12 +28,12 @@
 0.00000   1.00000   ! F_FlpCornerFreq   - Corner frequency and damping in the second order low pass filter of the blade root bending moment for flap control [rad/s, -].
 
 !------- BLADE PITCH CONTROL ----------------------------------------------
-27                  ! PC_GS_n			- Amount of gain-scheduling table entries
-0.063580  0.091667  0.113820  0.132927  0.150163  0.165982  0.180787  0.194909  0.208461  0.221269  0.233885  0.245874  0.257736  0.269106  0.280469  0.291234  0.302266  0.312525  0.322919  0.333308  0.342993  0.352949  0.362942  0.372100  0.381515  0.391200  0.400190                ! PC_GS_angles	    - Gain-schedule table: pitch angles
--0.013001  -0.011195  -0.009748  -0.008563  -0.007574  -0.006736  -0.006017  -0.005394  -0.004848  -0.004367  -0.003938  -0.003554  -0.003209  -0.002897  -0.002612  -0.002353  -0.002115  -0.001896  -0.001693  -0.001506  -0.001332  -0.001170  -0.001019  -0.000877  -0.000745  -0.000620  -0.000503                ! PC_GS_KP		- Gain-schedule table: pitch controller kp gains
--0.005660  -0.005036  -0.004536  -0.004126  -0.003785  -0.003495  -0.003247  -0.003031  -0.002843  -0.002676  -0.002528  -0.002396  -0.002276  -0.002168  -0.002070  -0.001980  -0.001898  -0.001822  -0.001752  -0.001688  -0.001628  -0.001572  -0.001519  -0.001470  -0.001425  -0.001381  -0.001341                ! PC_GS_KI		- Gain-schedule table: pitch controller ki gains
-0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_KD			- Gain-schedule table: pitch controller kd gains
-0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_TF			- Gain-schedule table: pitch controller tf gains (derivative filter)
+30                  ! PC_GS_n			- Amount of gain-scheduling table entries
+0.057184  0.084679  0.106097  0.124429  0.140845  0.155934  0.170053  0.183401  0.196139  0.208359  0.220146  0.231564  0.242647  0.253450  0.263988  0.274301  0.284401  0.294305  0.304033  0.313597  0.323005  0.332262  0.341382  0.350374  0.359244  0.367996  0.376635  0.385162  0.393584  0.401904                ! PC_GS_angles	    - Gain-schedule table: pitch angles [rad].
+-0.017430  -0.015265  -0.013508  -0.012054  -0.010831  -0.009787  -0.008886  -0.008101  -0.007410  -0.006798  -0.006251  -0.005760  -0.005317  -0.004915  -0.004548  -0.004213  -0.003905  -0.003620  -0.003358  -0.003114  -0.002887  -0.002676  -0.002478  -0.002293  -0.002119  -0.001956  -0.001802  -0.001656  -0.001519  -0.001389                ! PC_GS_KP		- Gain-schedule table: pitch controller kp gains [s].
+-0.005822  -0.005216  -0.004724  -0.004317  -0.003975  -0.003683  -0.003431  -0.003211  -0.003018  -0.002846  -0.002693  -0.002556  -0.002432  -0.002319  -0.002217  -0.002123  -0.002037  -0.001957  -0.001884  -0.001815  -0.001752  -0.001693  -0.001637  -0.001586  -0.001537  -0.001491  -0.001448  -0.001408  -0.001369  -0.001333                ! PC_GS_KI		- Gain-schedule table: pitch controller ki gains [-].
+0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_KD			- Gain-schedule table: pitch controller kd gains
+0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_TF			- Gain-schedule table: pitch controller tf gains (derivative filter)
 1.570800000000      ! PC_MaxPit			- Maximum physical pitch limit, [rad].
 0.000000000000      ! PC_MinPit			- Minimum physical pitch limit, [rad].
 0.174500000000      ! PC_MaxRat			- Maximum pitch rate (in absolute value) in pitch controller, [rad/s].

--- a/Tune_Cases/DISCON.IN
+++ b/Tune_Cases/DISCON.IN
@@ -1,5 +1,5 @@
 ! Controller parameter input file for the IEA-15-240-RWT-UMaineSemi wind turbine
-!    - File written using ROSCO version 2.3.0 controller tuning logic on 08/04/21
+!    - File written using ROSCO version 2.3.0 controller tuning logic on 08/20/21
 
 !------- DEBUG ------------------------------------------------------------
 1                   ! LoggingLevel		- {0: write no debug files, 1: write standard output .dbg-file, 2: write standard output .dbg-file and complete avrSWAP-array .dbg2-file}
@@ -8,14 +8,14 @@
 2                   ! F_LPFType			- {1: first-order low-pass filter, 2: second-order low-pass filter}, [rad/s] (currently filters generator speed and pitch control signals
 2                   ! F_NotchType		- Notch on the measured generator speed and/or tower fore-aft motion (for floating) {0: disable, 1: generator speed, 2: tower-top fore-aft motion, 3: generator speed and tower-top fore-aft motion}
 0                   ! IPC_ControlMode	- Turn Individual Pitch Control (IPC) for fatigue load reductions (pitch contribution) {0: off, 1: 1P reductions, 2: 1P+2P reductions}
-3                   ! VS_ControlMode	- Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR tracking PI control}
+2                   ! VS_ControlMode	- Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR tracking PI control}
 1                   ! PC_ControlMode    - Blade pitch control mode {0: No pitch, fix to fine pitch, 1: active PI blade pitch control}
 0                   ! Y_ControlMode		- Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
 1                   ! SS_Mode           - Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
 2                   ! WE_Mode           - Wind speed estimator mode {0: One-second low pass filtered hub height wind speed, 1: Immersion and Invariance Estimator, 2: Extended Kalman Filter}
 1                   ! PS_Mode           - Pitch saturation mode {0: no pitch saturation, 1: implement pitch saturation}
 0                   ! SD_Mode           - Shutdown mode {0: no shutdown procedure, 1: pitch to max pitch at shutdown}
-1                   ! Fl_Mode           - Floating specific feedback mode {0: no nacelle velocity feedback, 1: nacelle velocity feedback}
+2                   ! Fl_Mode           - Floating specific feedback mode {0: no nacelle velocity feedback, 1: nacelle velocity feedback}
 0                   ! Flp_Mode          - Flap control mode {0: no flap control, 1: steady state flap angle, 2: Proportional flap control}
 
 !------- FILTERS ----------------------------------------------------------
@@ -29,9 +29,9 @@
 
 !------- BLADE PITCH CONTROL ----------------------------------------------
 30                  ! PC_GS_n			- Amount of gain-scheduling table entries
-0.059995  0.086946  0.108285  0.126708  0.143267  0.158484  0.172690  0.186094  0.198845  0.211044  0.222781  0.234115  0.245094  0.255762  0.266153  0.276293  0.286207  0.295911  0.305426  0.314767  0.323945  0.332972  0.341860  0.350613  0.359245  0.367758  0.376162  0.384461  0.392657  0.400762                ! PC_GS_angles	    - Gain-schedule table: pitch angles [rad].
--1.515638  -1.328113  -1.172796  -1.042046  -0.930462  -0.834117  -0.750088  -0.676157  -0.610606  -0.552086  -0.499525  -0.452055  -0.408972  -0.369694  -0.333738  -0.300700  -0.270239  -0.242065  -0.215928  -0.191617  -0.168946  -0.147754  -0.127902  -0.109266  -0.091738  -0.075222  -0.059632  -0.044894  -0.030938  -0.017705                ! PC_GS_KP		- Gain-schedule table: pitch controller kp gains [s].
--0.131754  -0.119377  -0.109125  -0.100494  -0.093129  -0.086770  -0.081223  -0.076344  -0.072017  -0.068154  -0.064685  -0.061551  -0.058708  -0.056115  -0.053742  -0.051561  -0.049550  -0.047691  -0.045966  -0.044361  -0.042865  -0.041466  -0.040155  -0.038925  -0.037768  -0.036678  -0.035649  -0.034676  -0.033755  -0.032882                ! PC_GS_KI		- Gain-schedule table: pitch controller ki gains [-].
+0.060683  0.087433  0.108570  0.126809  0.143182  0.158231  0.172273  0.185522  0.198122  0.210183  0.221780  0.232979  0.243834  0.254376  0.264646  0.274672  0.284470  0.294064  0.303472  0.312709  0.321787  0.330716  0.339507  0.348169  0.356709  0.365135  0.373452  0.381666  0.389784  0.397808                ! PC_GS_angles	    - Gain-schedule table: pitch angles [rad].
+-3.811712  -3.407304  -3.072613  -2.791042  -2.550874  -2.343603  -2.162903  -2.003972  -1.863099  -1.737374  -1.624476  -1.522539  -1.430039  -1.345725  -1.268556  -1.197660  -1.132303  -1.071860  -1.015796  -0.963653  -0.915032  -0.869590  -0.827023  -0.787068  -0.749491  -0.714086  -0.680669  -0.649079  -0.619169  -0.590809                ! PC_GS_KP		- Gain-schedule table: pitch controller kp gains [s].
+-0.289550  -0.262237  -0.239633  -0.220617  -0.204397  -0.190398  -0.178194  -0.167461  -0.157947  -0.149456  -0.141831  -0.134946  -0.128699  -0.123005  -0.117793  -0.113005  -0.108591  -0.104509  -0.100723  -0.097201  -0.093917  -0.090848  -0.087973  -0.085275  -0.082737  -0.080346  -0.078089  -0.075956  -0.073936  -0.072020                ! PC_GS_KI		- Gain-schedule table: pitch controller ki gains [-].
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_KD			- Gain-schedule table: pitch controller kd gains
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_TF			- Gain-schedule table: pitch controller tf gains (derivative filter)
 1.570000000000      ! PC_MaxPit			- Maximum physical pitch limit, [rad].
@@ -55,12 +55,12 @@
 21586451.33303      ! VS_MaxTq			- Maximum generator torque in Region 3 (HSS side), [Nm].
 0.000000000000      ! VS_MinTq			- Minimum generator (HSS side), [Nm].
 0.523600000000      ! VS_MinOMSpd		- Optimal mode minimum speed, cut-in speed towards optimal mode gain path, [rad/s]
-34298026.20768      ! VS_Rgn2K			- Generator torque constant in Region 2 (HSS side), [Nm/(rad/s)^2]
+34505815.52476      ! VS_Rgn2K			- Generator torque constant in Region 2 (HSS side), [Nm/(rad/s)^2]
 15000000.00000      ! VS_RtPwr			- Wind turbine rated power [W]
 19624046.66639      ! VS_RtTq			- Rated torque, [Nm].
 0.791680000000      ! VS_RefSpd			- Rated generator speed [rad/s]
 1                   ! VS_n				- Number of generator PI torque controller gains
--38734288.78718      ! VS_KP				- Proportional gain for generator PI torque controller [-]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
+-39034030.68778      ! VS_KP				- Proportional gain for generator PI torque controller [-]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
 -4588245.18720      ! VS_KI				- Integral gain for generator PI torque controller [s]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
 9.00                ! VS_TSRopt			- Power-maximizing region 2 tip-speed-ratio [rad].
 
@@ -77,10 +77,10 @@
 318628138.00000      ! WE_Jtot			- Total drivetrain inertia, including blades, hub and casted generator inertia to LSS, [kg m^2]
 1.225               ! WE_RhoAir			- Air density, [kg m^-3]
 "/Users/nabbas/Documents/WindEnergyToolbox/ROSCO/Tune_Cases/Cp_Ct_Cq.IEA15MW.txt"      ! PerfFileName      - File containing rotor performance tables (Cp,Ct,Cq)
-130     85          ! PerfTableSize     - Size of rotor performance tables, first number refers to number of blade pitch angles, second number referse to number of tip-speed ratios
+104     48          ! PerfTableSize     - Size of rotor performance tables, first number refers to number of blade pitch angles, second number referse to number of tip-speed ratios
 60                  ! WE_FOPoles_N      - Number of first-order system poles used in EKF
 3.00 3.27 3.53 3.80 4.07 4.33 4.60 4.87 5.14 5.40 5.67 5.94 6.20 6.47 6.74 7.00 7.27 7.54 7.80 8.07 8.34 8.60 8.87 9.14 9.41 9.67 9.94 10.21 10.47 10.74 11.22 11.69 12.17 12.64 13.12 13.59 14.07 14.54 15.02 15.49 15.97 16.44 16.92 17.39 17.87 18.35 18.82 19.30 19.77 20.25 20.72 21.20 21.67 22.15 22.62 23.10 23.57 24.05 24.52 25.00               ! WE_FOPoles_v      - Wind speeds corresponding to first-order system poles [m/s]
--0.02361311 -0.02571386 -0.02781462 -0.02991537 -0.03201612 -0.03411687 -0.03621763 -0.03831838 -0.04041913 -0.04251989 -0.04462064 -0.04672139 -0.04882214 -0.05092290 -0.05302365 -0.05512440 -0.05722515 -0.05932591 -0.06142666 -0.06352741 -0.06562817 -0.06772892 -0.06982967 -0.07193042 -0.07403118 -0.07613193 -0.07823268 -0.08033343 -0.08243419 -0.07962330 0.02137945 0.01900621 0.01274289 0.00458224 -0.00491735 -0.01541008 -0.02666641 -0.03859697 -0.05111002 -0.06415580 -0.07768757 -0.09167630 -0.10609186 -0.12089224 -0.13609366 -0.15168879 -0.16762606 -0.18393867 -0.20058447 -0.21758108 -0.23489487 -0.25253208 -0.27047564 -0.28872452 -0.30725108 -0.32607739 -0.34517454 -0.36452453 -0.38414730 -0.40402270               ! WE_FOPoles        - First order system poles [1/s]
+-0.02334364 -0.02542042 -0.02749720 -0.02957398 -0.03165076 -0.03372754 -0.03580432 -0.03788110 -0.03995788 -0.04203466 -0.04411143 -0.04618821 -0.04826499 -0.05034177 -0.05241855 -0.05449533 -0.05657211 -0.05864889 -0.06072567 -0.06280245 -0.06487923 -0.06695601 -0.06903278 -0.07110956 -0.07318634 -0.07526312 -0.07733990 -0.07941668 -0.08149346 -0.08119577 -0.05454346 -0.05695037 -0.06335518 -0.07173786 -0.08143862 -0.09212647 -0.10361954 -0.11576910 -0.12850182 -0.14177876 -0.15556708 -0.16981797 -0.18445675 -0.19956215 -0.21503774 -0.23089771 -0.24714044 -0.26373464 -0.28068814 -0.29797559 -0.31560008 -0.33353280 -0.35180528 -0.37035226 -0.38920331 -0.40835512 -0.42775936 -0.44742679 -0.46737873 -0.48757093               ! WE_FOPoles        - First order system poles [1/s]
 
 !------- YAW CONTROL ------------------------------------------------------
 0.0                 ! Y_ErrThresh		- Yaw error threshold. Turbine begins to yaw when it passes this. [rad^2 s]
@@ -103,14 +103,14 @@
 !------- MINIMUM PITCH SATURATION -------------------------------------------
 60                  ! PS_BldPitchMin_N  - Number of values in minimum blade pitch lookup table (should equal number of values in PS_WindSpeeds and PS_BldPitchMin)
 3.0000 3.2669 3.5338 3.8007 4.0676 4.3345 4.6014 4.8683 5.1352 5.4021 5.6690 5.9359 6.2028 6.4697 6.7366 7.0034 7.2703 7.5372 7.8041 8.0710 8.3379 8.6048 8.8717 9.1386 9.4055 9.6724 9.9393 10.2062 10.4731 10.7400 11.2153 11.6907 12.1660 12.6413 13.1167 13.5920 14.0673 14.5427 15.0180 15.4933 15.9687 16.4440 16.9193 17.3947 17.8700 18.3453 18.8207 19.2960 19.7713 20.2467 20.7220 21.1973 21.6727 22.1480 22.6233 23.0987 23.5740 24.0493 24.5247 25.0000               ! PS_WindSpeeds     - Wind speeds corresponding to minimum blade pitch angles [m/s]
-0.06943047 0.06920530 0.06806353 0.06598274 0.06308229 0.05946612 0.05527332 0.05054712 0.04518674 0.03923470 0.03273357 0.02585881 0.01875262 0.01148737 0.00419638 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.01087082 0.02549057 0.03819411 0.04942020 0.05950125 0.06664075 0.07714898 0.08724005 0.09700731 0.10651541 0.11580833 0.12491476 0.13385954 0.14266232 0.15133637 0.15989668 0.16835188 0.17671262 0.18498854 0.19318156 0.20130199 0.20935425 0.21734042 0.22526632 0.23313517 0.24095054 0.24871056 0.25642198 0.26408556 0.27170233 0.27927550 0.28680225 0.29428652 0.30173037 0.30913283 0.31649562               ! PS_BldPitchMin    - Minimum blade pitch angles [rad]
+0.06096404 0.06096404 0.06096404 0.06096404 0.06096404 0.05989354 0.05575228 0.05107426 0.04580190 0.03987284 0.03342335 0.02657588 0.01947577 0.01221943 0.00493408 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00840069 0.02280570 0.03537141 0.04647892 0.05404517 0.06482739 0.07508321 0.08495204 0.09451935 0.10383907 0.11295080 0.12188355 0.13065966 0.13929783 0.14781427 0.15622063 0.16452836 0.17274642 0.18088282 0.18894375 0.19693548 0.20486135 0.21272286 0.22052830 0.22827982 0.23598030 0.24362922 0.25122962 0.25878539 0.26629954 0.27376630 0.28119278 0.28858074 0.29592793 0.30323465               ! PS_BldPitchMin    - Minimum blade pitch angles [rad]
 
 !------- SHUTDOWN -----------------------------------------------------------
 0.698100000000      ! SD_MaxPit         - Maximum blade pitch angle to initiate shutdown, [rad]
 0.418880000000      ! SD_CornerFreq     - Cutoff Frequency for first order low-pass filter for blade pitch angle, [rad/s]
 
 !------- Floating -----------------------------------------------------------
--0.06492000000      ! Fl_Kp             - Nacelle velocity proportional feedback gain [s]
+-9.32022000000      ! Fl_Kp             - Nacelle velocity proportional feedback gain [s]
 
 !------- FLAP ACTUATION -----------------------------------------------------
 0.000000000000      ! Flp_Angle         - Initial or steady state flap angle [rad]

--- a/Tune_Cases/DISCON.IN
+++ b/Tune_Cases/DISCON.IN
@@ -1,86 +1,86 @@
-! Controller parameter input file for the DTU_10MW_RWT wind turbine
-!    - File written using ROSCO Controller tuning logic on 03/01/20
+! Controller parameter input file for the IEA-15-240-RWT-UMaineSemi wind turbine
+!    - File written using ROSCO version 2.3.0 controller tuning logic on 08/04/21
 
 !------- DEBUG ------------------------------------------------------------
 1                   ! LoggingLevel		- {0: write no debug files, 1: write standard output .dbg-file, 2: write standard output .dbg-file and complete avrSWAP-array .dbg2-file}
 
 !------- CONTROLLER FLAGS -------------------------------------------------
-1                   ! F_LPFType			- {1: first-order low-pass filter, 2: second-order low-pass filter}, [rad/s] (currently filters generator speed and pitch control signals
-0                   ! F_NotchType		- Notch on the measured generator speed and/or tower fore-aft motion (for floating) {0: disable, 1: generator speed, 2: tower-top fore-aft motion, 3: generator speed and tower-top fore-aft motion}
+2                   ! F_LPFType			- {1: first-order low-pass filter, 2: second-order low-pass filter}, [rad/s] (currently filters generator speed and pitch control signals
+2                   ! F_NotchType		- Notch on the measured generator speed and/or tower fore-aft motion (for floating) {0: disable, 1: generator speed, 2: tower-top fore-aft motion, 3: generator speed and tower-top fore-aft motion}
 0                   ! IPC_ControlMode	- Turn Individual Pitch Control (IPC) for fatigue load reductions (pitch contribution) {0: off, 1: 1P reductions, 2: 1P+2P reductions}
-2                   ! VS_ControlMode	- Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR tracking PI control}
+3                   ! VS_ControlMode	- Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR tracking PI control}
 1                   ! PC_ControlMode    - Blade pitch control mode {0: No pitch, fix to fine pitch, 1: active PI blade pitch control}
 0                   ! Y_ControlMode		- Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
 1                   ! SS_Mode           - Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
 2                   ! WE_Mode           - Wind speed estimator mode {0: One-second low pass filtered hub height wind speed, 1: Immersion and Invariance Estimator, 2: Extended Kalman Filter}
-0                   ! PS_Mode           - Pitch saturation mode {0: no pitch saturation, 1: implement pitch saturation}
+1                   ! PS_Mode           - Pitch saturation mode {0: no pitch saturation, 1: implement pitch saturation}
 0                   ! SD_Mode           - Shutdown mode {0: no shutdown procedure, 1: pitch to max pitch at shutdown}
-0                   ! Fl_Mode           - Floating specific feedback mode {0: no nacelle velocity feedback, 1: nacelle velocity feedback}
+1                   ! Fl_Mode           - Floating specific feedback mode {0: no nacelle velocity feedback, 1: nacelle velocity feedback}
 0                   ! Flp_Mode          - Flap control mode {0: no flap control, 1: steady state flap angle, 2: Proportional flap control}
 
 !------- FILTERS ----------------------------------------------------------
-1.12975             ! F_LPFCornerFreq	- Corner frequency (-3dB point) in the low-pass filters, [rad/s]
-0.00000             ! F_LPFDamping		- Damping coefficient [used only when F_FilterType = 2]
-0.00000             ! F_NotchCornerFreq	- Natural frequency of the notch filter, [rad/s]
+1.00810             ! F_LPFCornerFreq	- Corner frequency (-3dB point) in the low-pass filters, [rad/s]
+0.70000             ! F_LPFDamping		- Damping coefficient {used only when F_FilterType = 2} [-]
+3.35500             ! F_NotchCornerFreq	- Natural frequency of the notch filter, [rad/s]
 0.00000   0.25000   ! F_NotchBetaNumDen	- Two notch damping values (numerator and denominator, resp) - determines the width and depth of the notch, [-]
-0.628320000000      ! F_SSCornerFreq    - Corner frequency (-3dB point) in the first order low pass filter for the setpoint smoother, [rad/s].
-0.00000   1.00000   ! F_FlCornerFreq    - Natural frequency and damping in the second order low pass filter of the tower-top fore-aft motion for floating feedback control [rad/s, -].
-0.00000   1.00000   ! F_FlpCornerFreq   - Corner frequency and damping in the second order low pass filter of the blade root bending moment for flap control [rad/s, -].
+0.628300000000      ! F_SSCornerFreq    - Corner frequency (-3dB point) in the first order low pass filter for the setpoint smoother, [rad/s].
+0.21300   1.00000   ! F_FlCornerFreq    - Natural frequency and damping in the second order low pass filter of the tower-top fore-aft motion for floating feedback control [rad/s, -].
+1.16240   1.00000   ! F_FlpCornerFreq   - Corner frequency and damping in the second order low pass filter of the blade root bending moment for flap control [rad/s, -].
 
 !------- BLADE PITCH CONTROL ----------------------------------------------
-27                  ! PC_GS_n			- Amount of gain-scheduling table entries
-0.076651  0.104597  0.126580  0.145538  0.162607  0.178351  0.193067  0.206924  0.220170  0.232969  0.245214  0.257052  0.268731  0.279797  0.290953  0.301452  0.312171  0.322210  0.332433  0.342284  0.351964  0.361902  0.371025  0.380350  0.389927  0.398615  0.407506                ! PC_GS_angles	    - Gain-schedule table: pitch angles
--0.028157  -0.024262  -0.021126  -0.018547  -0.016389  -0.014557  -0.012981  -0.011612  -0.010412  -0.009350  -0.008405  -0.007558  -0.006794  -0.006102  -0.005473  -0.004898  -0.004370  -0.003883  -0.003434  -0.003018  -0.002631  -0.002271  -0.001935  -0.001620  -0.001324  -0.001047  -0.000785                ! PC_GS_KP		- Gain-schedule table: pitch controller kp gains
--0.005563  -0.004963  -0.004479  -0.004081  -0.003748  -0.003466  -0.003223  -0.003011  -0.002826  -0.002662  -0.002517  -0.002386  -0.002268  -0.002161  -0.002064  -0.001976  -0.001894  -0.001819  -0.001750  -0.001686  -0.001626  -0.001571  -0.001519  -0.001470  -0.001424  -0.001382  -0.001341                ! PC_GS_KI		- Gain-schedule table: pitch controller ki gains
-0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_KD			- Gain-schedule table: pitch controller kd gains
-0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_TF			- Gain-schedule table: pitch controller tf gains (derivative filter)
-1.570800000000      ! PC_MaxPit			- Maximum physical pitch limit, [rad].
-0.013090000000      ! PC_MinPit			- Minimum physical pitch limit, [rad].
-0.174500000000      ! PC_MaxRat			- Maximum pitch rate (in absolute value) in pitch controller, [rad/s].
--0.17450000000      ! PC_MinRat			- Minimum pitch rate (in absolute value) in pitch controller, [rad/s].
-50.26500000000      ! PC_RefSpd			- Desired (reference) HSS speed for pitch controller, [rad/s].
-0.013090000000      ! PC_FinePit		- Record 5: Below-rated pitch angle set-point, [rad]
+30                  ! PC_GS_n			- Amount of gain-scheduling table entries
+0.059995  0.086946  0.108285  0.126708  0.143267  0.158484  0.172690  0.186094  0.198845  0.211044  0.222781  0.234115  0.245094  0.255762  0.266153  0.276293  0.286207  0.295911  0.305426  0.314767  0.323945  0.332972  0.341860  0.350613  0.359245  0.367758  0.376162  0.384461  0.392657  0.400762                ! PC_GS_angles	    - Gain-schedule table: pitch angles [rad].
+-1.515638  -1.328113  -1.172796  -1.042046  -0.930462  -0.834117  -0.750088  -0.676157  -0.610606  -0.552086  -0.499525  -0.452055  -0.408972  -0.369694  -0.333738  -0.300700  -0.270239  -0.242065  -0.215928  -0.191617  -0.168946  -0.147754  -0.127902  -0.109266  -0.091738  -0.075222  -0.059632  -0.044894  -0.030938  -0.017705                ! PC_GS_KP		- Gain-schedule table: pitch controller kp gains [s].
+-0.131754  -0.119377  -0.109125  -0.100494  -0.093129  -0.086770  -0.081223  -0.076344  -0.072017  -0.068154  -0.064685  -0.061551  -0.058708  -0.056115  -0.053742  -0.051561  -0.049550  -0.047691  -0.045966  -0.044361  -0.042865  -0.041466  -0.040155  -0.038925  -0.037768  -0.036678  -0.035649  -0.034676  -0.033755  -0.032882                ! PC_GS_KI		- Gain-schedule table: pitch controller ki gains [-].
+0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_KD			- Gain-schedule table: pitch controller kd gains
+0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0                ! PC_GS_TF			- Gain-schedule table: pitch controller tf gains (derivative filter)
+1.570000000000      ! PC_MaxPit			- Maximum physical pitch limit, [rad].
+0.000000000000      ! PC_MinPit			- Minimum physical pitch limit, [rad].
+0.034900000000      ! PC_MaxRat			- Maximum pitch rate (in absolute value) in pitch controller, [rad/s].
+-0.03490000000      ! PC_MinRat			- Minimum pitch rate (in absolute value) in pitch controller, [rad/s].
+0.791680000000      ! PC_RefSpd			- Desired (reference) HSS speed for pitch controller, [rad/s].
+0.000000000000      ! PC_FinePit		- Record 5: Below-rated pitch angle set-point, [rad]
 0.017450000000      ! PC_Switch			- Angle above lowest minimum pitch angle for switch, [rad]
 
 !------- INDIVIDUAL PITCH CONTROL -----------------------------------------
-0.0                 ! IPC_IntSat		- Integrator saturation (maximum signal amplitude contribution to pitch from IPC), [rad]
-0.0   0.0           ! IPC_KI			- Integral gain for the individual pitch controller: first parameter for 1P reductions, second for 2P reductions, [-]
-0.0   0.0           ! IPC_aziOffset		- Phase offset added to the azimuth angle for the individual pitch controller, [rad]. 
+0.1                 ! IPC_IntSat		- Integrator saturation (maximum signal amplitude contribution to pitch from IPC), [rad]
+0.0e+00       0.0   ! IPC_KI			- Integral gain for the individual pitch controller: first parameter for 1P reductions, second for 2P reductions, [-]
+0.0e+00       0.0   ! IPC_aziOffset		- Phase offset added to the azimuth angle for the individual pitch controller, [rad]. 
 0.0                 ! IPC_CornerFreqAct - Corner frequency of the first-order actuators model, to induce a phase lag in the IPC signal {0: Disable}, [rad/s]
 
 !------- VS TORQUE CONTROL ------------------------------------------------
-100.0000000000      ! VS_GenEff			- Generator efficiency mechanical power -> electrical power, [should match the efficiency defined in the generator properties!], [%]
-198945.5883800      ! VS_ArSatTq		- Above rated generator torque PI control saturation, [Nm]
-5000000.000000      ! VS_MaxRat			- Maximum torque rate (in absolute value) in torque controller, [Nm/s].
-218840.1472200      ! VS_MaxTq			- Maximum generator torque in Region 3 (HSS side), [Nm].
+96.55000000000      ! VS_GenEff			- Generator efficiency mechanical power -> electrical power, [should match the efficiency defined in the generator properties!], [%]
+19624046.66639      ! VS_ArSatTq		- Above rated generator torque PI control saturation, [Nm]
+4500000.000000      ! VS_MaxRat			- Maximum torque rate (in absolute value) in torque controller, [Nm/s].
+21586451.33303      ! VS_MaxTq			- Maximum generator torque in Region 3 (HSS side), [Nm].
 0.000000000000      ! VS_MinTq			- Minimum generator (HSS side), [Nm].
-17.96935000000      ! VS_MinOMSpd		- Optimal mode minimum speed, cut-in speed towards optimal mode gain path, [rad/s]
-79.43986000000      ! VS_Rgn2K			- Generator torque constant in Region 2 (HSS side), [N-m/(rad/s)^2]
-10000000.00000      ! VS_RtPwr			- Wind turbine rated power [W]
-198945.5883800      ! VS_RtTq			- Rated torque, [Nm].
-50.26500000000      ! VS_RefSpd			- Rated generator speed [rad/s]
+0.523600000000      ! VS_MinOMSpd		- Optimal mode minimum speed, cut-in speed towards optimal mode gain path, [rad/s]
+34298026.20768      ! VS_Rgn2K			- Generator torque constant in Region 2 (HSS side), [Nm/(rad/s)^2]
+15000000.00000      ! VS_RtPwr			- Wind turbine rated power [W]
+19624046.66639      ! VS_RtTq			- Rated torque, [Nm].
+0.791680000000      ! VS_RefSpd			- Rated generator speed [rad/s]
 1                   ! VS_n				- Number of generator PI torque controller gains
--14012.8768100      ! VS_KP				- Proportional gain for generator PI torque controller [1/(rad/s) Nm]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
--2561.58852000      ! VS_KI				- Integral gain for generator PI torque controller [1/rad Nm]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
-8.01                ! VS_TSRopt			- Power-maximizing region 2 tip-speed-ratio [rad].
+-38734288.78718      ! VS_KP				- Proportional gain for generator PI torque controller [-]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
+-4588245.18720      ! VS_KI				- Integral gain for generator PI torque controller [s]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
+9.00                ! VS_TSRopt			- Power-maximizing region 2 tip-speed-ratio [rad].
 
 !------- SETPOINT SMOOTHER ---------------------------------------------
 1.00000             ! SS_VSGain         - Variable speed torque controller setpoint smoother gain, [-].
 0.00100             ! SS_PCGain         - Collective pitch controller setpoint smoother gain, [-].
 
 !------- WIND SPEED ESTIMATOR ---------------------------------------------
-89.200              ! WE_BladeRadius	- Blade length (distance from hub center to blade tip), [m]
+120.000             ! WE_BladeRadius	- Blade length (distance from hub center to blade tip), [m]
 1                   ! WE_CP_n			- Amount of parameters in the Cp array
-0.0 0.0 0.0 0.0     ! WE_CP - Parameters that define the parameterized CP(lambda) function
+0.0               ! WE_CP - Parameters that define the parameterized CP(lambda) function
 0.0          		! WE_Gamma			- Adaption gain of the wind speed estimator algorithm [m/rad]
-50.0                ! WE_GearboxRatio	- Gearbox ratio [>=1],  [-]
-160099282.20800      ! WE_Jtot			- Total drivetrain inertia, including blades, hub and casted generator inertia to LSS, [kg m^2]
+1.0                 ! WE_GearboxRatio	- Gearbox ratio [>=1],  [-]
+318628138.00000      ! WE_Jtot			- Total drivetrain inertia, including blades, hub and casted generator inertia to LSS, [kg m^2]
 1.225               ! WE_RhoAir			- Air density, [kg m^-3]
-"Cp_Ct_Cq.IEA15MW.txt"      ! PerfFileName      - File containing rotor performance tables (Cp,Ct,Cq)
-104     72          ! PerfTableSize     - Size of rotor performance tables, first number refers to number of blade pitch angles, second number referse to number of tip-speed ratios
+"/Users/nabbas/Documents/WindEnergyToolbox/ROSCO/Tune_Cases/Cp_Ct_Cq.IEA15MW.txt"      ! PerfFileName      - File containing rotor performance tables (Cp,Ct,Cq)
+130     85          ! PerfTableSize     - Size of rotor performance tables, first number refers to number of blade pitch angles, second number referse to number of tip-speed ratios
 60                  ! WE_FOPoles_N      - Number of first-order system poles used in EKF
-3.00 3.27 3.53 3.80 4.07 4.33 4.60 4.87 5.14 5.40 5.67 5.94 6.20 6.47 6.74 7.00 7.27 7.54 7.80 8.07 8.34 8.60 8.87 9.14 9.41 9.67 9.94 10.21 10.47 10.74 10.74 11.23 11.72 12.22 12.71 13.20 13.69 14.18 14.67 15.17 15.66 16.15 16.64 17.13 17.62 18.12 18.61 19.10 19.59 20.08 20.57 21.07 21.56 22.05 22.54 23.03 23.52 24.02 24.51 25.00               ! WE_FOPoles_v      - Wind speeds corresponding to first-order system poles [m/s]
--0.02366483 -0.02577018 -0.02787553 -0.02998089 -0.03208624 -0.03419159 -0.03629695 -0.03840230 -0.04050765 -0.04261301 -0.04471836 -0.04682371 -0.04892907 -0.05103442 -0.05313977 -0.05524513 -0.05735048 -0.05945583 -0.06156119 -0.06366654 -0.06577189 -0.06787725 -0.06998260 -0.07208795 -0.07419331 -0.07629866 -0.07840401 -0.08050937 -0.08261472 -0.08472008 -0.07921295 -0.05358619 -0.05636426 -0.06307564 -0.07173987 -0.08172495 -0.09271927 -0.10454428 -0.11705643 -0.13017613 -0.14379976 -0.15793978 -0.17258746 -0.18766434 -0.20315149 -0.21909644 -0.23538854 -0.25208919 -0.26915631 -0.28659300 -0.30437969 -0.32249538 -0.34096095 -0.35974552 -0.37881117 -0.39822177 -0.41789494 -0.43785131 -0.45808118 -0.47857910               ! WE_FOPoles        - First order system poles [1/s]
+3.00 3.27 3.53 3.80 4.07 4.33 4.60 4.87 5.14 5.40 5.67 5.94 6.20 6.47 6.74 7.00 7.27 7.54 7.80 8.07 8.34 8.60 8.87 9.14 9.41 9.67 9.94 10.21 10.47 10.74 11.22 11.69 12.17 12.64 13.12 13.59 14.07 14.54 15.02 15.49 15.97 16.44 16.92 17.39 17.87 18.35 18.82 19.30 19.77 20.25 20.72 21.20 21.67 22.15 22.62 23.10 23.57 24.05 24.52 25.00               ! WE_FOPoles_v      - Wind speeds corresponding to first-order system poles [m/s]
+-0.02361311 -0.02571386 -0.02781462 -0.02991537 -0.03201612 -0.03411687 -0.03621763 -0.03831838 -0.04041913 -0.04251989 -0.04462064 -0.04672139 -0.04882214 -0.05092290 -0.05302365 -0.05512440 -0.05722515 -0.05932591 -0.06142666 -0.06352741 -0.06562817 -0.06772892 -0.06982967 -0.07193042 -0.07403118 -0.07613193 -0.07823268 -0.08033343 -0.08243419 -0.07962330 0.02137945 0.01900621 0.01274289 0.00458224 -0.00491735 -0.01541008 -0.02666641 -0.03859697 -0.05111002 -0.06415580 -0.07768757 -0.09167630 -0.10609186 -0.12089224 -0.13609366 -0.15168879 -0.16762606 -0.18393867 -0.20058447 -0.21758108 -0.23489487 -0.25253208 -0.27047564 -0.28872452 -0.30725108 -0.32607739 -0.34517454 -0.36452453 -0.38414730 -0.40402270               ! WE_FOPoles        - First order system poles [1/s]
 
 !------- YAW CONTROL ------------------------------------------------------
 0.0                 ! Y_ErrThresh		- Yaw error threshold. Turbine begins to yaw when it passes this. [rad^2 s]
@@ -91,29 +91,29 @@
 0.0                 ! Y_IPC_omegaLP		- Low-pass filter corner frequency for the Yaw-by-IPC controller to filtering the yaw alignment error, [rad/s].
 0.0                 ! Y_IPC_zetaLP		- Low-pass filter damping factor for the Yaw-by-IPC controller to filtering the yaw alignment error, [-].
 0.0                 ! Y_MErrSet			- Yaw alignment error, set point [rad]
-0.0                 ! Y_omegaLPFast		- Corner frequency fast low pass filter, 1.0 [Hz]
-0.0                 ! Y_omegaLPSlow		- Corner frequency slow low pass filter, 1/60 [Hz]
+0.0                 ! Y_omegaLPFast		- Corner frequency fast low pass filter, 1.0 [rad/s]
+0.0                 ! Y_omegaLPSlow		- Corner frequency slow low pass filter, 1/60 [rad/s]
 0.0                 ! Y_Rate			- Yaw rate [rad/s]
 
 !------- TOWER FORE-AFT DAMPING -------------------------------------------
 -1                  ! FA_KI				- Integral gain for the fore-aft tower damper controller, -1 = off / >0 = on [rad s/m] - !NJA - Make this a flag
-0.0                 ! FA_HPF_CornerFreq	- Corner frequency (-3dB point) in the high-pass filter on the fore-aft acceleration signal [rad/s]
+0.0                 ! FA_HPFCornerFreq	- Corner frequency (-3dB point) in the high-pass filter on the fore-aft acceleration signal [rad/s]
 0.0                 ! FA_IntSat			- Integrator saturation (maximum signal amplitude contribution to pitch from FA damper), [rad]
 
 !------- MINIMUM PITCH SATURATION -------------------------------------------
-42                  ! PS_BldPitchMin_N  - Number of values in minimum blade pitch lookup table (should equal number of values in PS_WindSpeeds and PS_BldPitchMin)
-4.00 4.50 5.00 5.50 6.00 6.50 7.00 7.50 8.00 8.50 9.00 9.50 10.00 10.50 11.00 11.90 12.40 12.90 13.40 13.90 14.40 14.90 15.40 15.90 16.40 16.90 17.40 17.90 18.40 18.90 19.40 19.90 20.40 20.90 21.40 21.90 22.40 22.90 23.40 23.90 24.40 24.90               ! PS_WindSpeeds     - Wind speeds corresponding to minimum blade pitch angles [m/s]
-0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997 0.01308997               ! PS_BldPitchMin    - Minimum blade pitch angles [rad]
+60                  ! PS_BldPitchMin_N  - Number of values in minimum blade pitch lookup table (should equal number of values in PS_WindSpeeds and PS_BldPitchMin)
+3.0000 3.2669 3.5338 3.8007 4.0676 4.3345 4.6014 4.8683 5.1352 5.4021 5.6690 5.9359 6.2028 6.4697 6.7366 7.0034 7.2703 7.5372 7.8041 8.0710 8.3379 8.6048 8.8717 9.1386 9.4055 9.6724 9.9393 10.2062 10.4731 10.7400 11.2153 11.6907 12.1660 12.6413 13.1167 13.5920 14.0673 14.5427 15.0180 15.4933 15.9687 16.4440 16.9193 17.3947 17.8700 18.3453 18.8207 19.2960 19.7713 20.2467 20.7220 21.1973 21.6727 22.1480 22.6233 23.0987 23.5740 24.0493 24.5247 25.0000               ! PS_WindSpeeds     - Wind speeds corresponding to minimum blade pitch angles [m/s]
+0.06943047 0.06920530 0.06806353 0.06598274 0.06308229 0.05946612 0.05527332 0.05054712 0.04518674 0.03923470 0.03273357 0.02585881 0.01875262 0.01148737 0.00419638 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000 0.01087082 0.02549057 0.03819411 0.04942020 0.05950125 0.06664075 0.07714898 0.08724005 0.09700731 0.10651541 0.11580833 0.12491476 0.13385954 0.14266232 0.15133637 0.15989668 0.16835188 0.17671262 0.18498854 0.19318156 0.20130199 0.20935425 0.21734042 0.22526632 0.23313517 0.24095054 0.24871056 0.25642198 0.26408556 0.27170233 0.27927550 0.28680225 0.29428652 0.30173037 0.30913283 0.31649562               ! PS_BldPitchMin    - Minimum blade pitch angles [rad]
 
 !------- SHUTDOWN -----------------------------------------------------------
-0.407510000000      ! SD_MaxPit         - Maximum blade pitch angle to initiate shutdown, [rad]
+0.698100000000      ! SD_MaxPit         - Maximum blade pitch angle to initiate shutdown, [rad]
 0.418880000000      ! SD_CornerFreq     - Cutoff Frequency for first order low-pass filter for blade pitch angle, [rad/s]
 
 !------- Floating -----------------------------------------------------------
-0.000000000000      ! Fl_Kp             - Nacelle velocity proportional feedback gain [s]
+-0.06492000000      ! Fl_Kp             - Nacelle velocity proportional feedback gain [s]
 
 !------- FLAP ACTUATION -----------------------------------------------------
 0.000000000000      ! Flp_Angle         - Initial or steady state flap angle [rad]
 0.00000000e+00      ! Flp_Kp            - Blade root bending moment proportional gain for flap control [s]
-0.00000000e+00      ! Flp_Ki            - Flap displacement integral gain for flap control [s]
-0.000000000000      ! Flp_MaxPit        - Maximum (and minimum) flap pitch angle [rad]
+0.00000000e+00      ! Flp_Ki            - Flap displacement integral gain for flap control [-]
+0.174500000000      ! Flp_MaxPit        - Maximum (and minimum) flap pitch angle [rad]

--- a/Tune_Cases/IEA15MW.yaml
+++ b/Tune_Cases/IEA15MW.yaml
@@ -36,7 +36,7 @@ controller_params:
   WE_Mode:            2                     # Wind speed estimator mode {0: One-second low pass filtered hub height wind speed, 1: Immersion and Invariance Estimator (Ortega et al.)}
   PS_Mode:            3                     # Pitch saturation mode {0: no pitch saturation, 1: peak shaving, 2: Cp-maximizing pitch saturation, 3: peak shaving and Cp-maximizing pitch saturation}
   SD_Mode:            0                     # Shutdown mode {0: no shutdown procedure, 1: pitch to max pitch at shutdown}
-  Fl_Mode:            1                     # Floating specific feedback mode {0: no nacelle velocity feedback, 1: nacelle velocity feedback}
+  Fl_Mode:            2                     # Floating specific feedback mode {0: no nacelle velocity feedback, 1: nacelle velocity feedback}
   Flp_Mode:           0                     # Flap control mode {0: no flap control, 1: steady state flap angle, 2: Proportional flap control}
   # Controller parameters       
   # U_pc:               [14]

--- a/Tune_Cases/NREL5MW.yaml
+++ b/Tune_Cases/NREL5MW.yaml
@@ -32,7 +32,7 @@ controller_params:
   F_LPFType:          1                     # {1: first-order low-pass filter, 2: second-order low-pass filter}, [rad/s] (currently filters generator speed and pitch control signals)
   F_NotchType:        0                     # Notch filter on generator speed and/or tower fore-aft motion (for floating) {0: disable, 1: generator speed, 2: tower-top fore-aft motion, 3: generator speed and tower-top fore-aft motion}
   IPC_ControlMode:    0                     # Turn Individual Pitch Control (IPC) for fatigue load reductions (pitch contribution) {0: off, 1: 1P reductions, 2: 1P+2P reductions}
-  VS_ControlMode:     2                     # Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR tracking PI control}
+  VS_ControlMode:     3                     # Generator torque control mode in above rated conditions {0: constant torque, 1: constant power, 2: TSR tracking PI control}
   PC_ControlMode:     1                     # Blade pitch control mode {0: No pitch, fix to fine pitch, 1: active PI blade pitch control}
   Y_ControlMode:      0                     # Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
   SS_Mode:            1                     # Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
@@ -42,11 +42,11 @@ controller_params:
   Fl_Mode:            0                     # Floating specific feedback mode {0: no nacelle velocity feedback, 1: nacelle velocity feedback}
   Flp_Mode:           0                     # Flap control mode {0: no flap control, 1: steady state flap angle, 2: Proportional flap control}
   # Controller parameters 
-  U_pc:               [12]
-  zeta_pc:            [0.7]                   # Pitch controller desired damping ratio [-]
-  omega_pc:           [0.5]                   # Pitch controller desired natural frequency [rad/s]
+  # U_pc:               [12]
+  zeta_pc:            0.7                   # Pitch controller desired damping ratio [-]
+  omega_pc:           0.6                   # Pitch controller desired natural frequency [rad/s]
   zeta_vs:            0.7                   # Torque controller desired damping ratio [-]
-  omega_vs:           0.2                   # Torque controller desired natural frequency [rad/s]
+  omega_vs:           0.15                   # Torque controller desired natural frequency [rad/s]
   # Only needed if Flp_Mode > 0
   # zeta_flp:           # None                  # Flap controller desired damping ratio [-]
   # omega_flp:          # None                  # Flap controller desired natural frequency [rad/s]

--- a/Tune_Cases/tune_ROSCO.py
+++ b/Tune_Cases/tune_ROSCO.py
@@ -5,7 +5,7 @@ import os
 #-------------------------------- LOAD INPUT PARAMETERS ---------------------------------#
 # Change this for your turbine
 this_dir            = os.path.dirname(__file__)
-parameter_filename  = os.path.join(this_dir,'NREL5MW.yaml')                         # Name of .yaml input file for the specific turbine
+parameter_filename  = os.path.join(this_dir,'IEA15MW.yaml')                         # Name of .yaml input file for the specific turbine
 
 
 
@@ -23,13 +23,14 @@ import yaml
 from ROSCO_toolbox import controller as ROSCO_controller
 from ROSCO_toolbox import turbine as ROSCO_turbine
 from ROSCO_toolbox.utilities import write_rotor_performance, write_DISCON
+from ROSCO_toolbox.inputs.validation import load_rosco_yaml
 
 # Initialize parameter dictionaries
 turbine_params = {}
 control_params = {}
 
 # Load input file contents, put them in some dictionaries to keep things cleaner
-inps = yaml.safe_load(open(parameter_filename))
+inps = load_rosco_yaml(parameter_filename)
 path_params = inps['path_params']
 turbine_params = inps['turbine_params']
 controller_params = inps['controller_params']

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - scipy
   - pyYAML
   - pandas
+  - wisdem

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ class CMakeBuildExt(build_ext):
                     cmake_args += ['-DCMAKE_GENERATOR_PLATFORM=x64']
                 else:
                     cmake_args += ['-G', 'MinGW Makefiles']
-                    cmake_args += ['-D', 'CMAKE_Fortran_COMPILER=gfortran']
 
             self.build_temp = os.path.join( os.path.dirname( os.path.realpath(__file__) ), 'ROSCO', 'build')
             os.makedirs(localdir, exist_ok=True)


### PR DESCRIPTION
## Description and Purpose
This brings in some updates that have been made based on reviewer comments to the WES-preprint about ROSCO:
https://wes.copernicus.org/preprints/wes-2021-19/

Two major changes:
1. Use the nacelle fore-aft translational velocity signal rather than the nacelle fore-aft angular velocity for the floating feedback term to be more consistent with the standard bladed interface
2. Update the controller tuning methods so that the system pole is modified in above-rated operation when the generator torque controller is set to constant-power operation

One minor change:
1. The TSR was not saturated properly in region 2.5, so it would stay constant even though the wind speed would be increasing and the rotor speed was constant. Now the TSR drops appropriately. 

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Github issues addressed, if one exists

## Examples/Testing, if applicable
Standard tests should pass

