### PR TITLE
Support Window's with MinGW builds in GH Actions

### DIFF
--- a/.github/workflows/CI_rosco-pytools.yml
+++ b/.github/workflows/CI_rosco-pytools.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 # Specify FORTRAN compiler
 env:
-  FORTRAN_COMPILER: gfortran-10
+  FC: gfortran
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -47,15 +47,7 @@ jobs:
         if: true == contains( matrix.os, 'macOS')
         run: |
           conda install compilers
-        
 
-      # Install ROSCO toolbox
-      - name: Install ROSCO toolbox - Windows
-        if: true == contains( matrix.os, 'windows')
-        env:
-          FC: gfortran
-        run: |
-          python setup.py develop --compile-rosco
 
       # Install ROSCO toolbox
       - name: Install ROSCO toolbox

--- a/.github/workflows/CI_rosco-pytools.yml
+++ b/.github/workflows/CI_rosco-pytools.yml
@@ -50,6 +50,14 @@ jobs:
         
 
       # Install ROSCO toolbox
+      - name: Install ROSCO toolbox - Windows
+        if: true == contains( matrix.os, 'windows')
+        env:
+          FC: gfortran
+        run: |
+          python setup.py develop --compile-rosco
+
+      # Install ROSCO toolbox
       - name: Install ROSCO toolbox
         run: |
           python setup.py develop --compile-rosco

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,6 @@ metadata = dict(
     url                           = URL,
     install_requires              = REQUIRED,
     python_requires               = REQUIRES_PYTHON,
-    # include_package_date          = True,
     packages                      = find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
     license                       = 'Apache License, Version 2.0',
     cmdclass                      = {'build_ext': CMakeBuildExt, 'upload': UploadCommand},

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,10 @@ class CMakeBuildExt(build_ext):
         super().copy_extensions_to_source()
     
     def build_extension(self, ext):
-        if isinstance(ext, CMakeExtension):
+        if not isinstance(ext, CMakeExtension):
+            super().build_extension(ext)
+
+        else:
             # Ensure that CMake is present and working
             try:
                 self.spawn(['cmake', '--version'])
@@ -105,8 +108,6 @@ class CMakeBuildExt(build_ext):
             self.spawn(['cmake', '-S', ext.sourcedir, '-B', self.build_temp] + cmake_args)
             self.spawn(['cmake', '--build', self.build_temp, '--target', 'install', '--config', 'Release'])
 
-        else:
-            super().build_extension(ext)
 
 
 # All of the extensions

--- a/setup.py
+++ b/setup.py
@@ -95,10 +95,11 @@ class CMakeBuildExt(build_ext):
             cmake_args += ['-DCMAKE_INSTALL_PREFIX={}'.format(localdir)]
 
             if platform.system() == 'Windows':
-                if self.compiler.compiler_type == 'msvc':
-                    cmake_args += ['-DCMAKE_GENERATOR_PLATFORM=x64']
-                else:
-                    cmake_args += ['-G', 'MinGW Makefiles']
+                # if self.compiler.compiler_type == 'msvc':
+                #     cmake_args += ['-DCMAKE_GENERATOR_PLATFORM=x64']
+                # else:
+                cmake_args += ['-G', 'MinGW Makefiles']
+                # cmake_args += ['-DCMAKE_Fortran_COMPILER=gfortran']
 
             self.build_temp = os.path.join( os.path.dirname( os.path.realpath(__file__) ), 'ROSCO', 'build')
             os.makedirs(localdir, exist_ok=True)
@@ -186,7 +187,7 @@ metadata = dict(
     url                           = URL,
     install_requires              = REQUIRED,
     python_requires               = REQUIRES_PYTHON,
-    include_package_date          = True,
+    # include_package_date          = True,
     packages                      = find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
     license                       = 'Apache License, Version 2.0',
     cmdclass                      = {'build_ext': CMakeBuildExt, 'upload': UploadCommand},

--- a/setup.py
+++ b/setup.py
@@ -95,11 +95,12 @@ class CMakeBuildExt(build_ext):
             cmake_args += ['-DCMAKE_INSTALL_PREFIX={}'.format(localdir)]
 
             if platform.system() == 'Windows':
-                # if self.compiler.compiler_type == 'msvc':
-                #     cmake_args += ['-DCMAKE_GENERATOR_PLATFORM=x64']
-                # else:
-                cmake_args += ['-G', 'MinGW Makefiles']
-                # cmake_args += ['-DCMAKE_Fortran_COMPILER=gfortran']
+                if "gfortran" in os.environ["FC"].lower():
+                    cmake_args += ['-G', 'MinGW Makefiles']
+                elif self.compiler.compiler_type == 'msvc':
+                    cmake_args += ['-DCMAKE_GENERATOR_PLATFORM=x64']
+                else:
+                    raise ValueError("Unable to find the system's Fortran compiler.")
 
             self.build_temp = os.path.join( os.path.dirname( os.path.realpath(__file__) ), 'ROSCO', 'build')
             os.makedirs(localdir, exist_ok=True)


### PR DESCRIPTION
## Description and Purpose
This changes the GitHub Actions configuration to support building on Windows with MinGW compilers. Specifically, the `FORTRAN_COMPILER` environment variables was previously not used, so I changed this to `FC` and the value is simply `gfortran`. This enables CMake to find the latest gfortran available on the system. For the Windows builds, this will be gfortran installed via conda. For macOS, this will be gfortran-11.2. And for linux, this will be 10.3.

Additionally, this pull request changes the setup.py file's method for checking which system is running. The class `build_ext` in distutils automatically checks for the system and assigns a compiler toolchain to `self.compiler`. However, it simply checks for the OS type, so it sets `msvc` for all Windows systems. While it may be possible to override `self.compiler`, I thought it safer to check for the FC environment variable first, and then proceed as usual.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Github issues addressed, if one exists

## Examples/Testing, if applicable


