### PR TITLE
add bld edgewise freq to robust dict_inputs

### DIFF
--- a/ROSCO_toolbox/linear/robust_scheduling.py
+++ b/ROSCO_toolbox/linear/robust_scheduling.py
@@ -66,6 +66,7 @@ class RobustScheduling(om.ExplicitComponent):
             self.turbine.Ct_table = np.squeeze(dict_inputs['Ct_table'])
             self.turbine.Cq_table = np.squeeze(dict_inputs['Cq_table'])
             self.turbine.pitch_initial_rad = dict_inputs['pitch_vector']
+            self.turbine.bld_edgewise_freq = float(dict_inputs['edge_freq'])
             self.turbine.TSR_initial = dict_inputs['tsr_vector']
             RotorPerformance = ROSCO_turbine.RotorPerformance
             self.turbine.Cp = RotorPerformance(


### PR DESCRIPTION
## Description and Purpose
Add blade edgewise frequency to the dict_inputs in the robust scheduling. This enables linking with WEIS.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Github issues addressed, if one exists

## Examples/Testing, if applicable

