### PR TITLE
Update example_08.py

### DIFF
--- a/Examples/example_08.py
+++ b/Examples/example_08.py
@@ -46,7 +46,7 @@ fast_out = output_processing.output_processing()
 # fast_out.plot_fast_out()
 
 # Load and plot
-fastout = fast_out.load_fast_out(filenames, tmin=10)
+fastout = fast_out.load_fast_out(filenames)
 fast_out.plot_fast_out(cases=cases,showplot=False)
 
 plt.savefig(os.path.join(example_out_dir,'08_IEA-15MW_Semi_Out.png'))


### PR DESCRIPTION
Remove tmin so that entire simulation is plotted. Removing tmin=10 because with that setting only the final timestep of the simulation is loaded.

## Description and Purpose
Before this change I was getting this plot when running example_08 which confused me because it appeared to be empty:
![before](https://user-images.githubusercontent.com/9821851/203772197-ad3986cd-c01e-4087-9f35-b3a7fb36b81f.png)

After comparing the variable fastout to IEA-15-240-RWT-UMaineSemi.out I realized only the last row of the file was being loaded and plotted. I tried removing tmin=10 and that worked. The plot after this change:
![after](https://user-images.githubusercontent.com/9821851/203772226-5fbc08e1-37cd-4113-af12-fb9fd02718ae.png)

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

TODO Items General:
- [ ] Add example/test for new feature
- [ ] Update registry
- [ ] Run testing

TODO Items API Change:
- [ ] Update docs with API change
- [ ] Run update_rosco_discons.py in Test_Cases/
- [ ] Update DISCON schema

## Github issues addressed, if one exists

## Examples/Testing, if applicable

