### PR TITLE
Address readthedocs depreciating use of 'system_packages'

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,4 +24,3 @@ python:
       path: .
       extra_requirements:
         - docs
-  system_packages: true 


### PR DESCRIPTION
## Description and Purpose
Readthedocs is depreciating a feature where 'system_packages' was used in ```.readthedocs.yaml``` to include some preloaded libraries. 

## Type of change
Small change in `.readthedocs.yaml`. 
The change does not affect rest of the code and builds the documentation without any issue.

_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

TODO Items General:
- [ ] Add example/test for new feature
- [ ] Update registry
- [ ] Run testing

TODO Items API Change:
- [ ] Update docs with API change
- [ ] Run update_rosco_discons.py in Test_Cases/
- [ ] Update DISCON schema

## Github issues addressed, if one exists

## Examples/Testing, if applicable
Test readthedocs documentation build again after August 29, 2023 to ensure that everything works fine after the depreciation. 
