### PR TITLE
Add types to scalars

### DIFF
--- a/.github/workflows/CI_rosco-compile.yml
+++ b/.github/workflows/CI_rosco-compile.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "windows-latest"] # , "macOS-latest"
+        os: ["ubuntu-latest", "windows-latest" , "macOS-latest"]
         python-version: ["3.9"]    
 
     steps:
@@ -34,6 +34,7 @@ jobs:
           environment-file: environment.yml
           activate-environment: test
           auto-activate-base: false
+          miniforge-variant: Mambaforge
 
       # Install ROSCO toolbox
       - name: Install ROSCO toolbox

--- a/.github/workflows/CI_rosco-compile.yml
+++ b/.github/workflows/CI_rosco-compile.yml
@@ -22,14 +22,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup environment
+      - name: Install conda/mamba
         uses: conda-incubator/setup-miniconda@v2
+        # https://github.com/marketplace/actions/setup-miniconda
         with:
-          miniconda-version: "latest"
-          channels: conda-forge, general
+          # To use mamba, uncomment here, comment out the miniforge line
+          mamba-version: "*"
+          # miniforge-version: "latest"
           auto-update-conda: true
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
+          activate-environment: test
+          auto-activate-base: false
 
       # Install ROSCO toolbox
       - name: Install ROSCO toolbox

--- a/.github/workflows/CI_rosco-compile.yml
+++ b/.github/workflows/CI_rosco-compile.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest"] # , "macOS-latest"
         python-version: ["3.9"]    
 
     steps:

--- a/.github/workflows/CI_rosco-pytools.yml
+++ b/.github/workflows/CI_rosco-pytools.yml
@@ -32,13 +32,14 @@ jobs:
         # https://github.com/marketplace/actions/setup-miniconda
         with:
           # To use mamba, uncomment here, comment out the miniforge line
-          # mamba-version: "*"
-          miniforge-version: "latest"
+          mamba-version: "*"
+          # miniforge-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
           activate-environment: test
           auto-activate-base: false
+          miniforge-variant: Mambaforge
 
 
       # Install dependencies of ROSCO toolbox

--- a/.github/workflows/CI_rosco-pytools.yml
+++ b/.github/workflows/CI_rosco-pytools.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]  # "macOS-latest",
+        os: ["ubuntu-latest", "windows-latest", "macOS-latest"]
         python-version: ["3.9"]
     defaults:
       run:
@@ -88,14 +88,19 @@ jobs:
         with:
           submodules: recursive
       
-      - name: Setup environment
+      - name: Install conda/mamba
         uses: conda-incubator/setup-miniconda@v2
+        # https://github.com/marketplace/actions/setup-miniconda
         with:
-          miniconda-version: "latest"
-          channels: conda-forge, general
+          # To use mamba, uncomment here, comment out the miniforge line
+          mamba-version: "*"
+          # miniforge-version: "latest"
           auto-update-conda: true
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
+          activate-environment: test
+          auto-activate-base: false
+          miniforge-variant: Mambaforge
 
       # setup cmake
       - name: Setup Workspace

--- a/.github/workflows/CI_rosco-pytools.yml
+++ b/.github/workflows/CI_rosco-pytools.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest"]  # "macOS-latest",
         python-version: ["3.9"]
     defaults:
       run:
@@ -27,14 +27,18 @@ jobs:
         with:
           submodules: recursive
       
-      - name: Setup environment
+      - name: Install conda/mamba
         uses: conda-incubator/setup-miniconda@v2
+        # https://github.com/marketplace/actions/setup-miniconda
         with:
-          miniconda-version: "latest"
-          channels: conda-forge, general
+          # To use mamba, uncomment here, comment out the miniforge line
+          # mamba-version: "*"
+          miniforge-version: "latest"
           auto-update-conda: true
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
+          activate-environment: test
+          auto-activate-base: false
 
 
       # Install dependencies of ROSCO toolbox

--- a/.github/workflows/CI_rosco-pytools.yml
+++ b/.github/workflows/CI_rosco-pytools.yml
@@ -180,14 +180,19 @@ jobs:
         with:
           submodules: recursive
       
-      - name: Setup environment
+      - name: Install conda/mamba
         uses: conda-incubator/setup-miniconda@v2
+        # https://github.com/marketplace/actions/setup-miniconda
         with:
-          miniconda-version: "latest"
-          channels: conda-forge, general
+          # To use mamba, uncomment here, comment out the miniforge line
+          mamba-version: "*"
+          # miniforge-version: "latest"
           auto-update-conda: true
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
+          activate-environment: test
+          auto-activate-base: false
+          miniforge-variant: Mambaforge
 
 
       # Install dependencies of ROSCO toolbox

--- a/ROSCO/src/Controllers.f90
+++ b/ROSCO/src/Controllers.f90
@@ -704,7 +704,7 @@ CONTAINS
                 IF (CntrPar%AWC_NumModes == 1) THEN
                     AWC_TiltYaw(2) = PI/180*CntrPar%AWC_amp(1)*cos(LocalVar%Time*2*PI*CntrPar%AWC_freq(1) + 2*CntrPar%AWC_clockangle(1)*PI/180)
                 ENDIF
-                CALL ColemanTransformInverse(AWC_TiltYaw(1), AWC_TiltYaw(2), LocalVar%Azimuth, CntrPar%AWC_harmonic(Imode), 0.0, AWC_angle)
+                CALL ColemanTransformInverse(AWC_TiltYaw(1), AWC_TiltYaw(2), LocalVar%Azimuth, CntrPar%AWC_harmonic(Imode), REAL(0.0,DbKi), AWC_angle)
 
                 DO K = 1,LocalVar%NumBl ! Loop through all blades, apply AWC_angle
                     LocalVar%PitCom(K) = LocalVar%PitCom(K) + AWC_angle(K)
@@ -775,7 +775,7 @@ CONTAINS
         DO I_GROUP = 1, CntrPar%CC_Group_N
 
             ! Get Actuated deltaL
-            LocalVar%CC_ActuatedDL(I_GROUP) = SecLPFilter_Vel(LocalVar%CC_DesiredL(I_GROUP),LocalVar%DT,2*PI/CntrPar%CC_ActTau,1.0, &
+            LocalVar%CC_ActuatedDL(I_GROUP) = SecLPFilter_Vel(LocalVar%CC_DesiredL(I_GROUP),LocalVar%DT,2*PI/CntrPar%CC_ActTau,REAL(1.0,DbKi), &
                                                                 LocalVar%FP,LocalVar%iStatus,LocalVar%restart,objInst%instSecLPFV)
 
             ! Integrate


### PR DESCRIPTION
## Description and Purpose
Some scalars did not have their type explicitly set. That resulted in a failed compilation using the `ifx` fortran compiler from IntelLLVM 2023.2.0 package on Kestrel. This change does not break compilation using cray-suggested `ftn` compiler.

Note: I'm not sure if `REAL(<scalar>,DbKi)` is really needed or just `<scalar>_BdKi` is enough. I think it might depend on whether or not the scalar need to be of real type. I put them as real to be safe.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

TODO Items General:
- [ ] Add example/test for new feature
- [ ] Update registry
- [ ] Run testing

TODO Items API Change:
- [ ] Update docs with API change
- [ ] Run update_rosco_discons.py in Test_Cases/
- [ ] Update DISCON schema

## Github issues addressed, if one exists

## Examples/Testing, if applicable

