### PR TITLE
Add various features and tests to ZeroMQ wind farm control implementation

### DIFF
--- a/Examples/17b_zeromq_multi_openfast.py
+++ b/Examples/17b_zeromq_multi_openfast.py
@@ -15,7 +15,7 @@ TIME_CHECK = 30
 DESIRED_YAW_OFFSET = [-10, 10]
 
 
-def run_zmq(logfile):
+def run_zmq(logfile=None):
     """Start the ZeroMQ server for wind farm control"""
 
     # Start the server at the following address

--- a/Examples/17b_zeromq_multi_openfast.py
+++ b/Examples/17b_zeromq_multi_openfast.py
@@ -11,7 +11,7 @@ from ROSCO_toolbox.ofTools.fast_io import output_processing
 this_dir = os.path.dirname(os.path.abspath(__file__))
 example_out_dir = os.path.join(this_dir, "examples_out")
 os.makedirs(example_out_dir, exist_ok=True)
-TIME_CHECK = 30
+TIME_CHECK = 20
 DESIRED_YAW_OFFSET = [-10, 10]
 
 
@@ -20,7 +20,7 @@ def run_zmq(logfile=None):
 
     # Start the server at the following address
     network_address = "tcp://*:5555"
-    server = wfc_zmq_server(network_address, timeout=60.0, verbose=True, logfile = logfile)
+    server = wfc_zmq_server(network_address, timeout=60.0, verbose=False, logfile = logfile)
 
     # Provide the wind farm control algorithm as the wfc_controller method of the server
     server.wfc_controller = wfc_controller
@@ -42,13 +42,20 @@ def wfc_controller(id, current_time, measurements):
     """
     if current_time <= 10.0:
         YawOffset = 0.0
+        col_pitch_command = 0.0
     else:
+        col_pitch_command = np.deg2rad(2) * np.sin(0.1 * current_time) + np.deg2rad(2) # Implement dynamic induction control
         if id == 1:
             YawOffset = DESIRED_YAW_OFFSET[0]
         else:
             YawOffset = DESIRED_YAW_OFFSET[1]
+
+        
     setpoints = {}
     setpoints["ZMQ_YawOffset"] = YawOffset
+    setpoints['ZMQ_PitOffset(1)'] = col_pitch_command
+    setpoints['ZMQ_PitOffset(2)'] = col_pitch_command
+    setpoints['ZMQ_PitOffset(3)'] = col_pitch_command
     return setpoints
 
 
@@ -59,7 +66,7 @@ def sim_openfast_1():
     r.wind_case_fcn = cl.power_curve
     r.wind_case_opts = {
         "U": [8],
-        "TMax": 100,
+        "TMax": 25,
     }
     run_dir = os.path.join(example_out_dir, "17b_zeromq_OF1")
     r.controller_params = {}
@@ -78,7 +85,7 @@ def sim_openfast_2():
     r.wind_case_fcn = cl.power_curve
     r.wind_case_opts = {
         "U": [8],
-        "TMax": 100,
+        "TMax": 25,
     }
     run_dir = os.path.join(example_out_dir, "17b_zeromq_OF2")
     r.save_dir = run_dir

--- a/Examples/17b_zeromq_multi_openfast.py
+++ b/Examples/17b_zeromq_multi_openfast.py
@@ -15,12 +15,12 @@ TIME_CHECK = 30
 DESIRED_YAW_OFFSET = [-10, 10]
 
 
-def run_zmq():
+def run_zmq(logfile):
     """Start the ZeroMQ server for wind farm control"""
 
     # Start the server at the following address
     network_address = "tcp://*:5555"
-    server = wfc_zmq_server(network_address, timeout=60.0, verbose=True)
+    server = wfc_zmq_server(network_address, timeout=60.0, verbose=True, logfile = logfile)
 
     # Provide the wind farm control algorithm as the wfc_controller method of the server
     server.wfc_controller = wfc_controller
@@ -93,7 +93,8 @@ def sim_openfast_2():
 if __name__ == "__main__":
     # Start wind farm control server and two openfast simulation
     # as separate processes
-    p0 = mp.Process(target=run_zmq)
+    logfile = os.path.join(example_out_dir,os.path.splitext(os.path.basename(__file__))[0]+'.log')
+    p0 = mp.Process(target=run_zmq,args=(logfile,))
     p1 = mp.Process(target=sim_openfast_1)
     p2 = mp.Process(target=sim_openfast_2)
 

--- a/ROSCO/src/ZeroMQInterface.f90
+++ b/ROSCO/src/ZeroMQInterface.f90
@@ -52,7 +52,6 @@ CONTAINS
 
             write (zmq_address, '(A,A)') TRIM(CntrPar%ZMQ_CommAddress), C_NULL_CHAR
 #ifdef ZMQ_CLIENT
-            write(*,*) 'Spawning a zeromq client and waiting for server...'
             call zmq_client(zmq_address, turbine_measurements, setpoints)
 #else
             ! Add RoutineName to error message

--- a/ROSCO/src/ZeroMQInterface.f90
+++ b/ROSCO/src/ZeroMQInterface.f90
@@ -52,6 +52,7 @@ CONTAINS
 
             write (zmq_address, '(A,A)') TRIM(CntrPar%ZMQ_CommAddress), C_NULL_CHAR
 #ifdef ZMQ_CLIENT
+            write(*,*) 'Spawning a zeromq client and waiting for server...'
             call zmq_client(zmq_address, turbine_measurements, setpoints)
 #else
             ! Add RoutineName to error message

--- a/ROSCO_toolbox/control_interface.py
+++ b/ROSCO_toolbox/control_interface.py
@@ -322,6 +322,8 @@ class wfc_zmq_server:
         Time till server time out
     verbose : bool
         Prints details of messages being passed using the server
+    logfile : string
+        Path of the logfile; if logfile is not provided, logging is disabled
 
     methods
     -------
@@ -339,7 +341,7 @@ class wfc_zmq_server:
     )
     wfc_interface = load_yaml(interface_file)
 
-    def __init__(self, network_address="tcp://*:5555", timeout=600.0, verbose=False,logfile=[]):
+    def __init__(self, network_address="tcp://*:5555", timeout=600.0, verbose=False,logfile=None):
         """Instanciate the server"""
         self.network_address = network_address
         self.timeout = timeout
@@ -361,6 +363,8 @@ class wfc_zmq_server:
             logger.addHandler(logger_filehandler)
         else:
             logging.disable()
+            if self.verbose:
+                print('Logging disabled')
 
         logger.info(
             f"Successfully established connection a ZeroMQ server at {network_address}"

--- a/ROSCO_toolbox/control_interface.py
+++ b/ROSCO_toolbox/control_interface.py
@@ -29,8 +29,9 @@ from ROSCO_toolbox.ofTools.util.FileTools import load_yaml
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-# logger.setLevel(logging.DEBUG)
+# Choose logging level below
+logger.setLevel(logging.INFO)       # For a basic level of logs 
+# logger.setLevel(logging.DEBUG)    # For more detailed logs helpful for debugging
 
 
 


### PR DESCRIPTION
## Add various features and tests to ZeroMQ implementation.
Wind farm control interface modified to spawn a single server which connects to multiple ROSCO clients. Examples added/modified to demonstrate the capability.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Examples/Testing, if applicable
Example 17a modified to reflect the new zeromq framework
Example 17b demonstrates wind farm control with zeromq framework
Both tests pass locally on a mac

