### PR TITLE
Add intel llvm to compilers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rosco"
-version = "2.9.0"
+version = "2.9.1"
 description = "A reference open source controller toolset for wind turbine applications."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/rosco/controller/CMakeLists.txt
+++ b/rosco/controller/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 message(STATUS "CMAKE_Fortran_COMPILER_ID = ${CMAKE_Fortran_COMPILER_ID}")
 if(APPLE OR UNIX)
 # Enable .dll export
-if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+if (CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DIMPLICIT_DLLEXPORT -r8 -double-size 64 -cpp -no-wrap-margin")
 else()
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DIMPLICIT_DLLEXPORT -ffree-line-length-0 -fdefault-real-8 -fdefault-double-8 -cpp")  


### PR DESCRIPTION
## Description and Purpose

Intel oneapi compilers on some machines such as NREL Kestrel are named `IntelLLVM`. This PR ensures that it gets picked up correctly.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Github issues addressed, if one exists
NA
## Examples/Testing, if applicable
NA
