### PR TITLE
Start using automatic documentation for examples

### DIFF
--- a/Examples/01_turbine_model.py
+++ b/Examples/01_turbine_model.py
@@ -1,16 +1,16 @@
-'''
------------ 01_turbine_model --------------
-Load and save a turbine model
--------------------------------------
-In this example:
-- Read .yaml input file
-- Load an openfast turbine model
-- Read text file with rotor performance properties
-- Print some basic turbine properties
-- Save the turbine as a picklle
+"""
+01_turbine_model
+----------------
+Load and save a turbine model.
+
+* Read .yaml input file
+* Load an openfast turbine model
+* Read text file with rotor performance properties
+* Print some basic turbine properties
+* Save the turbine as a picklle
 
 Note: Uses the NREL 5MW included in the Test Cases and is a part of the OpenFAST distribution
-'''
+"""
 
 # Python Modules
 import os
@@ -19,44 +19,48 @@ from rosco.toolbox import turbine as ROSCO_turbine
 from rosco.toolbox.inputs.validation import load_rosco_yaml
 import matplotlib.pyplot as plt
 
+def main():
+    # Load yaml file
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    tune_dir =  os.path.join(this_dir,'Tune_Cases')
+    parameter_filename = os.path.join(tune_dir,'NREL5MW.yaml')
+    inps = load_rosco_yaml(parameter_filename)
+    path_params         = inps['path_params']
+    turbine_params      = inps['turbine_params']
 
-# Load yaml file
-this_dir = os.path.dirname(os.path.abspath(__file__))
-tune_dir =  os.path.join(this_dir,'Tune_Cases')
-parameter_filename = os.path.join(tune_dir,'NREL5MW.yaml')
-inps = load_rosco_yaml(parameter_filename)
-path_params         = inps['path_params']
-turbine_params      = inps['turbine_params']
+    # Load turbine data from openfast model
+    turbine = ROSCO_turbine.Turbine(turbine_params)
 
-# Load turbine data from openfast model
-turbine = ROSCO_turbine.Turbine(turbine_params)
+    turbine.load_from_fast(
+        path_params['FAST_InputFile'],
+        os.path.join(tune_dir,path_params['FAST_directory']),
+        rot_source='txt',txt_filename=os.path.join(tune_dir,path_params['rotor_performance_filename'])
+        )
 
-turbine.load_from_fast(
-    path_params['FAST_InputFile'],
-    os.path.join(tune_dir,path_params['FAST_directory']),
-    rot_source='txt',txt_filename=os.path.join(tune_dir,path_params['rotor_performance_filename'])
-    )
+    # Print some basic turbine info
+    print(turbine)
 
-# Print some basic turbine info
-print(turbine)
+    # Save the turbine model
+    example_out_dir = os.path.join(this_dir,'examples_out')
+    if not os.path.isdir(example_out_dir):
+        os.makedirs(example_out_dir)
 
-# Save the turbine model
-example_out_dir = os.path.join(this_dir,'examples_out')
-if not os.path.isdir(example_out_dir):
-  os.makedirs(example_out_dir)
+    turbine.save(os.path.join(example_out_dir,'01_NREL5MW_saved.p'))
 
-turbine.save(os.path.join(example_out_dir,'01_NREL5MW_saved.p'))
+    # Now load the turbine and plot the Cp surface
 
-# Now load the turbine and plot the Cp surface
+    # Load quick from python pickle
+    turbine = turbine.load(os.path.join(example_out_dir,'01_NREL5MW_saved.p'))
 
-# Load quick from python pickle
-turbine = turbine.load(os.path.join(example_out_dir,'01_NREL5MW_saved.p'))
+    # plot rotor performance 
+    print('Plotting Cp data')
+    turbine.Cp.plot_performance()
 
-# plot rotor performance 
-print('Plotting Cp data')
-turbine.Cp.plot_performance()
+    if False:
+        plt.show()
+    else:
+        plt.savefig(os.path.join(example_out_dir,'01_NREL5MW_Cp.png'))
 
-if False:
-  plt.show()
-else:
-  plt.savefig(os.path.join(example_out_dir,'01_NREL5MW_Cp.png'))
+
+if __name__=='__main__':
+  main()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ import sys
 from datetime import date
 root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, root_path)
+sys.path.insert(0, os.path.join(root_path,'Examples'))
 
 # -- Project information -----------------------------------------------------
 
@@ -53,6 +54,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.autosectionlabel",
     "sphinx_rtd_theme",
+    "sphinx.ext.autodoc",
     # "sphinxcontrib.bibtex",
 ]
 
@@ -91,3 +93,6 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
+
+# Options for AutoDoc:
+add_module_names = False

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -98,3 +98,9 @@ By setting :code:`testtype`, the user can run a variety of tests:
 
 Setting the :code:`turbine2test` allows the user to test either the IEA-15MW with the UMaine floating semisubmersible or the NREL-5MW reference onshore turbine.
 
+
+List of Examples
+----------------
+A complete list of examples is given below:
+
+.. automodule:: 01_turbine_model


### PR DESCRIPTION
## Description and Purpose
This pull request implements the use of automatic documentation for documenting examples.
This is demonstrated with example-1.

Examples need to be modified so that the code is contained within a function.
Otherwise, examples get executed while building the documentation.
Also, the docstrings of other examples need to be modified to be in suitabl rst format like example-1



## Type of change
What types of change is it?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

TODO Items General:
- [ ] Add example/test for new feature
- [ ] Update registry
- [ ] Run testing
- [x] Update examples

TODO Items API Change:
- [ ] Update docs with API change
- [ ] Run update_rosco_discons.py in Test_Cases/
- [ ] Update DISCON schema

## Github issues addressed, if one exists

## Examples/Testing, if applicable

