### PR TITLE
Fixed bug where TRA_LastRefSpd was set to a generator speed not the L…

### DIFF
--- a/rosco/controller/src/ControllerBlocks.f90
+++ b/rosco/controller/src/ControllerBlocks.f90
@@ -490,7 +490,7 @@ CONTAINS
                     LocalVar%TRA_LastRefSpd = CntrPar%TRA_ExclSpeed - CntrPar%TRA_ExclBand / 2
                 ENDIF
             ELSE
-                LocalVar%TRA_LastRefSpd = LocalVar%VS_RefSpd
+                LocalVar%TRA_LastRefSpd = VS_RefSpeed_LSS
             END IF
         END IF 
 


### PR DESCRIPTION
…SS speed

## Description and Purpose
Hi. I believe I have found a bug in the `RefSpeedExclusion` subroutine. When `FA_Hist` is zero, currently `VS_RefSpd_TRA` is set to `VS_RefSpd`, which is based on the generator speed. I believe it should be set to `VS_RefSpeed_LSS`, which is based on the rotor speed.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

TODO Items General:
- [ ] Add example/test for new feature
- [ ] Update registry
- [ ] Run testing

TODO Items API Change:
- [ ] Update docs with API change
- [ ] Run update_rosco_discons.py in Test_Cases/
- [ ] Update DISCON schema

## Github issues addressed, if one exists

## Examples/Testing, if applicable

