### PR TITLE
fixes for numpy2 and newer windows gfortran

### DIFF
--- a/rosco/toolbox/control_interface.py
+++ b/rosco/toolbox/control_interface.py
@@ -20,6 +20,7 @@ from ctypes import (
     create_string_buffer,
     c_int32,
     c_void_p,
+    wintypes,
 )
 import numpy as np
 import platform
@@ -258,6 +259,7 @@ class ControllerInterface:
 
         if OS == "Windows":  # pragma: Windows
             try:
+                ctypes.windll.kernel32.FreeLibrary.argtypes = [wintypes.HMODULE]
                 _dlclose = ctypes.windll.kernel32.FreeLibrary
                 dlclose = lambda handle: 0 if _dlclose(handle) else 1
             except:

--- a/rosco/toolbox/ofTools/fast_io/output_processing.py
+++ b/rosco/toolbox/ofTools/fast_io/output_processing.py
@@ -366,7 +366,7 @@ def load_ascii_output(filename):
                 info['attribute_units'] = [unit[1:-1] for unit in f.readline().split()]
 
         # Data, up to end of file or empty line (potential comment line at the end)
-        data = np.array([l.strip().split() for l in takewhile(lambda x: len(x.strip())>0, f.readlines())]).astype(np.float_)
+        data = np.array([l.strip().split() for l in takewhile(lambda x: len(x.strip())>0, f.readlines())]).astype(np.float64)
         return data, info
 
 

--- a/rosco/toolbox/ofTools/util/FileTools.py
+++ b/rosco/toolbox/ofTools/util/FileTools.py
@@ -32,7 +32,7 @@ def remove_numpy(fst_vt):
                 
                 if data_type in [np.int_, np.intc, np.intp, np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64]:
                     get_dict(fst_vt, branch_i[:-1])[branch_i[-1]] = int(get_dict(fst_vt, branch_i[:-1])[branch_i[-1]])
-                elif data_type in [np.single, np.double, np.longdouble, np.csingle, np.cdouble, np.float_, np.float16, np.float32, np.float64, np.complex64, np.complex128]:
+                elif data_type in [np.single, np.double, np.longdouble, np.csingle, np.cdouble, np.float16, np.float32, np.float64, np.complex64, np.complex128]:
                     get_dict(fst_vt, branch_i[:-1])[branch_i[-1]] = float(get_dict(fst_vt, branch_i[:-1])[branch_i[-1]])
                 elif data_type in [np.bool_]:
                     get_dict(fst_vt, branch_i[:-1])[branch_i[-1]] = bool(get_dict(fst_vt, branch_i[:-1])[branch_i[-1]])


### PR DESCRIPTION
## Description and Purpose
Changes to support numpy v2 and handling of windows ctypes errors per #350 .  This changes were already applied in a patch in the conda packaging.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

TODO Items General:
- [ ] Add example/test for new feature
- [ ] Update registry
- [ ] Run testing

TODO Items API Change:
- [ ] Update docs with API change
- [ ] Run update_rosco_discons.py in Test_Cases/
- [ ] Update DISCON schema

## Github issues addressed, if one exists

## Examples/Testing, if applicable

